### PR TITLE
fix: hide macos window instead of closing app

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod pty;
 mod session;
 mod storage;
 mod usage;
+mod window_behavior;
 
 use session::{ClaudeSessionInfo, CodexSessionInfo};
 
@@ -47,6 +48,7 @@ impl TaskManager {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .on_window_event(window_behavior::handle_window_event)
         .setup(|_app| {
             // 后台预热 login shell 环境，避免第一次启动任务时阻塞
             std::thread::spawn(|| {
@@ -119,6 +121,7 @@ pub fn run() {
             notification::mark_all_notifications_read,
             usage::read_usage_snapshot,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(window_behavior::handle_run_event);
 }

--- a/src-tauri/src/window_behavior.rs
+++ b/src-tauri/src/window_behavior.rs
@@ -1,0 +1,54 @@
+#[cfg(target_os = "macos")]
+use tauri::Manager;
+
+const MAIN_WINDOW_LABEL: &str = "main";
+
+#[cfg(target_os = "macos")]
+fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+    if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
+        if window.show().is_err() {
+            return;
+        }
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn handle_window_event<R: tauri::Runtime>(
+    window: &tauri::Window<R>,
+    event: &tauri::WindowEvent,
+) {
+    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        if window.label() != MAIN_WINDOW_LABEL {
+            return;
+        }
+        api.prevent_close();
+        let _ = window.hide();
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn handle_window_event<R: tauri::Runtime>(
+    _window: &tauri::Window<R>,
+    _event: &tauri::WindowEvent,
+) {
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn handle_run_event<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    event: tauri::RunEvent,
+) {
+    if let tauri::RunEvent::Reopen { has_visible_windows, .. } = event {
+        if !has_visible_windows {
+            restore_main_window(app_handle);
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn handle_run_event<R: tauri::Runtime>(
+    _app_handle: &tauri::AppHandle<R>,
+    _event: tauri::RunEvent,
+) {
+}


### PR DESCRIPTION
  ## Summary

  This PR updates the macOS window lifecycle behavior so closing the main window hides the app window instead of
  terminating the application.

  ## Changes

  - intercept the main window close request on macOS
  - hide the main window instead of allowing it to close
  - restore and focus the main window when the app is reopened from the Dock
  - move the macOS-specific window behavior into a dedicated `window_behavior` module to keep `lib.rs` minimal

  ## Motivation
  alive.
  Before this change, closing the main window could effectively exit the app experience instead of matching native
  macOS behavior.

  ## Result

  - `Cmd+W` hides the main window on macOS
  - clicking the Dock icon brings the main window back
  - the app entrypoint remains focused on wiring, with platform-specific behavior isolated

  ## Scope

  This change only affects macOS window close/reopen behavior.
  It does not change task management, storage, session handling, or frontend state logic.

  ## Verification

  - verified by running `cargo test --lib`