### PR TITLE
fix: hide macos window after fullscreen exit

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2334,6 +2334,8 @@ dependencies = [
  "chrono",
  "libc",
  "notify",
+ "objc2",
+ "objc2-app-kit",
  "once_cell",
  "parking_lot",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,5 +41,9 @@ parking_lot = "0.12"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 uuid = { version = "1", features = ["v4"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSWindow"] }
+
 [profile.dev]
 debug = 0

--- a/src-tauri/src/window_behavior.rs
+++ b/src-tauri/src/window_behavior.rs
@@ -1,7 +1,78 @@
+use std::{
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+#[cfg(target_os = "macos")]
+use objc2::MainThreadMarker;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{NSApp, NSWindow};
+#[cfg(target_os = "macos")]
+use parking_lot::Mutex;
 #[cfg(target_os = "macos")]
 use tauri::Manager;
 
 const MAIN_WINDOW_LABEL: &str = "main";
+const FULLSCREEN_HIDE_DELAY: Duration = Duration::from_millis(500);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloseRequestAction {
+    HideImmediately,
+    ExitFullscreenThenHide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingHide {
+    None,
+    WaitingForFullscreenExit,
+    WaitingUntil(Instant),
+}
+
+#[derive(Debug)]
+struct MainWindowCloseState {
+    pending_hide: PendingHide,
+}
+
+impl MainWindowCloseState {
+    fn new() -> Self {
+        Self {
+            pending_hide: PendingHide::None,
+        }
+    }
+
+    fn on_close_requested(&mut self, is_fullscreen: bool) -> CloseRequestAction {
+        if is_fullscreen {
+            self.pending_hide = PendingHide::WaitingForFullscreenExit;
+            CloseRequestAction::ExitFullscreenThenHide
+        } else {
+            self.pending_hide = PendingHide::None;
+            CloseRequestAction::HideImmediately
+        }
+    }
+
+    fn on_main_events_cleared(&mut self, is_fullscreen: bool, now: Instant) -> bool {
+        match self.pending_hide {
+            PendingHide::None => false,
+            PendingHide::WaitingForFullscreenExit if is_fullscreen => false,
+            PendingHide::WaitingForFullscreenExit => {
+                self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
+                false
+            }
+            PendingHide::WaitingUntil(deadline) if now < deadline => false,
+            PendingHide::WaitingUntil(_) => {
+                self.pending_hide = PendingHide::None;
+                true
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.pending_hide = PendingHide::None;
+    }
+}
+
+#[cfg(target_os = "macos")]
+static MAIN_WINDOW_CLOSE_STATE: LazyLock<Mutex<MainWindowCloseState>> =
+    LazyLock::new(|| Mutex::new(MainWindowCloseState::new()));
 
 #[cfg(target_os = "macos")]
 fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
@@ -14,16 +85,52 @@ fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
 }
 
 #[cfg(target_os = "macos")]
+fn hide_main_window_natively<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+    let app_handle = app_handle.clone();
+    let app_handle_for_closure = app_handle.clone();
+    let _ = app_handle.run_on_main_thread(move || {
+        let mtm = MainThreadMarker::new().expect("window hide should run on main thread");
+        let app = NSApp(mtm);
+
+        if let Some(window) = app_handle_for_closure.get_webview_window(MAIN_WINDOW_LABEL) {
+            if let Ok(ns_window) = window.ns_window() {
+                let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
+                ns_window.orderOut(None);
+            }
+        }
+
+        app.hide(None);
+    });
+}
+
+#[cfg(target_os = "macos")]
 pub(crate) fn handle_window_event<R: tauri::Runtime>(
     window: &tauri::Window<R>,
     event: &tauri::WindowEvent,
 ) {
+    let is_main_window = window.label() == MAIN_WINDOW_LABEL;
+    if !is_main_window {
+        return;
+    }
+
     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-        if window.label() != MAIN_WINDOW_LABEL {
-            return;
+        let close_action = MAIN_WINDOW_CLOSE_STATE
+            .lock()
+            .on_close_requested(window.is_fullscreen().unwrap_or(false));
+
+        match close_action {
+            CloseRequestAction::HideImmediately => {
+                api.prevent_close();
+                hide_main_window_natively(&window.app_handle());
+            }
+            CloseRequestAction::ExitFullscreenThenHide => {
+                api.prevent_close();
+                if window.set_fullscreen(false).is_err() {
+                    MAIN_WINDOW_CLOSE_STATE.lock().reset();
+                    hide_main_window_natively(&window.app_handle());
+                }
+            }
         }
-        api.prevent_close();
-        let _ = window.hide();
     }
 }
 
@@ -39,10 +146,27 @@ pub(crate) fn handle_run_event<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     event: tauri::RunEvent,
 ) {
-    if let tauri::RunEvent::Reopen { has_visible_windows, .. } = event {
-        if !has_visible_windows {
-            restore_main_window(app_handle);
+    match event {
+        tauri::RunEvent::MainEventsCleared => {
+            if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
+                let should_hide = MAIN_WINDOW_CLOSE_STATE.lock().on_main_events_cleared(
+                    window.is_fullscreen().unwrap_or(false),
+                    Instant::now(),
+                );
+                if should_hide {
+                    hide_main_window_natively(app_handle);
+                }
+            }
         }
+        tauri::RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } => {
+            if !has_visible_windows {
+                restore_main_window(app_handle);
+            }
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## Summary

  Fix macOS window close behavior when the main window is in native fullscreen.

  Previously, `cmd+w` on macOS hid the app in normal window mode, but could leave the app in a bad state when the user had entered native fullscreen from the green traffic-light button. This change keeps the
  existing hide-on-close behavior for the main window while making fullscreen close handling safer.

  ## Changes

  - intercept macOS main-window `CloseRequested`
  - keep normal-window close behavior as hide instead of quitting
  - when the main window is in native fullscreen:
    - prevent immediate close
    - request exit from fullscreen first
    - wait for fullscreen exit to settle
    - then hide the app via native AppKit APIs
  - restore the main window on macOS app reopen
  - narrow `objc2-app-kit` features to only what this behavior needs

  ## Files

  - `src-tauri/src/window_behavior.rs`
  - `src-tauri/Cargo.toml`
  - `src-tauri/Cargo.lock`

  ## Verification

  Ran:

  ```bash
  cargo test --manifest-path src-tauri/Cargo.toml --lib -- --nocapture

  Result:

  - 15 tests passed
  - 0 failed

  ## Notes

  - This change is macOS-specific.
  - It uses native AppKit hide behavior through NSApp / NSWindow because Tauri does not expose a dedicated fullscreen-exit-complete event for this exact workflow.