### PR TITLE
fix: hide macos window after fullscreen exit

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2334,6 +2334,8 @@ dependencies = [
  "chrono",
  "libc",
  "notify",
+ "objc2",
+ "objc2-app-kit",
  "once_cell",
  "parking_lot",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,5 +41,9 @@ parking_lot = "0.12"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 uuid = { version = "1", features = ["v4"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSWindow"] }
+
 [profile.dev]
 debug = 0

--- a/src-tauri/src/window_behavior.rs
+++ b/src-tauri/src/window_behavior.rs
@@ -1,21 +1,27 @@
 #[cfg(target_os = "macos")]
 mod macos {
     use std::{
+        cell::RefCell,
         sync::LazyLock,
         time::{Duration, Instant},
     };
 
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApp, NSWindow};
+    use objc2::rc::Retained;
+    use objc2::{define_class, msg_send, sel, MainThreadMarker, MainThreadOnly};
+    use objc2_app_kit::{
+        NSApp, NSWindow, NSWindowDidExitFullScreenNotification, NSWindowStyleMask,
+    };
+    use objc2_foundation::{NSNotification, NSNotificationCenter, NSObject, NSObjectProtocol};
     use parking_lot::Mutex;
     use tauri::Manager;
 
     const MAIN_WINDOW_LABEL: &str = "main";
-    const FULLSCREEN_HIDE_DELAY: Duration = Duration::from_millis(500);
     const FULLSCREEN_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+    const HIDE_VERIFICATION_DELAY: Duration = Duration::from_millis(75);
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum CloseRequestAction {
+        None,
         HideImmediately,
         ExitFullscreenThenHide,
     }
@@ -25,13 +31,20 @@ mod macos {
         None,
         RetryExitFullscreen,
         Hide,
+        Stop,
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum PendingHide {
         None,
-        WaitingForFullscreenExitUntil(Instant),
-        WaitingUntil(Instant),
+        WaitingForFullscreenExit {
+            retry_count: u8,
+            deadline: Instant,
+        },
+        WaitingForHideVerification {
+            retry_count: u8,
+            verify_after: Instant,
+        },
     }
 
     #[derive(Debug)]
@@ -46,52 +59,100 @@ mod macos {
             }
         }
 
-        fn on_close_requested(
-            &mut self,
-            is_fullscreen: Option<bool>,
-            now: Instant,
-        ) -> CloseRequestAction {
-            match is_fullscreen {
-                Some(false) => {
-                    self.pending_hide = PendingHide::None;
-                    CloseRequestAction::HideImmediately
+        fn on_close_requested(&mut self, is_fullscreen: bool, now: Instant) -> CloseRequestAction {
+            match self.pending_hide {
+                PendingHide::None => {
+                    if is_fullscreen {
+                        self.pending_hide = PendingHide::WaitingForFullscreenExit {
+                            retry_count: 0,
+                            deadline: now + FULLSCREEN_EXIT_TIMEOUT,
+                        };
+                        CloseRequestAction::ExitFullscreenThenHide
+                    } else {
+                        self.pending_hide = PendingHide::WaitingForHideVerification {
+                            retry_count: 0,
+                            verify_after: now + HIDE_VERIFICATION_DELAY,
+                        };
+                        CloseRequestAction::HideImmediately
+                    }
                 }
-                Some(true) | None => {
-                    self.pending_hide =
-                        PendingHide::WaitingForFullscreenExitUntil(now + FULLSCREEN_EXIT_TIMEOUT);
-                    CloseRequestAction::ExitFullscreenThenHide
-                }
+                PendingHide::WaitingForFullscreenExit { .. } => CloseRequestAction::None,
+                PendingHide::WaitingForHideVerification { .. } => CloseRequestAction::None,
             }
         }
 
-        fn on_main_events_cleared(
+        fn on_fullscreen_exit_succeeded(&mut self, now: Instant) -> MainEventsAction {
+            match self.pending_hide {
+                PendingHide::WaitingForFullscreenExit { .. } => {
+                    self.pending_hide = PendingHide::WaitingForHideVerification {
+                        retry_count: 0,
+                        verify_after: now + HIDE_VERIFICATION_DELAY,
+                    };
+                    MainEventsAction::Hide
+                }
+                _ => MainEventsAction::None,
+            }
+        }
+
+        fn on_fullscreen_exit_progress(
             &mut self,
-            is_fullscreen: Option<bool>,
+            is_fullscreen: bool,
             now: Instant,
         ) -> MainEventsAction {
             match self.pending_hide {
-                PendingHide::None => MainEventsAction::None,
-                PendingHide::WaitingForFullscreenExitUntil(deadline) => match is_fullscreen {
-                    Some(false) => {
-                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
-                        MainEventsAction::None
-                    }
-                    Some(true) if now < deadline => MainEventsAction::None,
-                    Some(true) => {
-                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
-                        MainEventsAction::RetryExitFullscreen
-                    }
-                    None if now >= deadline => {
-                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
-                        MainEventsAction::None
-                    }
-                    None => MainEventsAction::None,
-                },
-                PendingHide::WaitingUntil(deadline) if now < deadline => MainEventsAction::None,
-                PendingHide::WaitingUntil(_) => {
-                    self.pending_hide = PendingHide::None;
+                PendingHide::WaitingForFullscreenExit { deadline, .. }
+                    if !is_fullscreen && now >= deadline =>
+                {
+                    self.pending_hide = PendingHide::WaitingForHideVerification {
+                        retry_count: 0,
+                        verify_after: now + HIDE_VERIFICATION_DELAY,
+                    };
                     MainEventsAction::Hide
                 }
+                PendingHide::WaitingForFullscreenExit { .. } if !is_fullscreen => {
+                    MainEventsAction::None
+                }
+                PendingHide::WaitingForFullscreenExit { deadline, .. } if now < deadline => {
+                    MainEventsAction::None
+                }
+                PendingHide::WaitingForFullscreenExit { retry_count: 0, .. } => {
+                    self.pending_hide = PendingHide::WaitingForFullscreenExit {
+                        retry_count: 1,
+                        deadline: now + FULLSCREEN_EXIT_TIMEOUT,
+                    };
+                    MainEventsAction::RetryExitFullscreen
+                }
+                PendingHide::WaitingForFullscreenExit { .. } => {
+                    self.pending_hide = PendingHide::None;
+                    MainEventsAction::Stop
+                }
+                _ => MainEventsAction::None,
+            }
+        }
+
+        fn on_hide_result(&mut self, hidden: bool, now: Instant) -> MainEventsAction {
+            match self.pending_hide {
+                PendingHide::WaitingForHideVerification { .. } if hidden => {
+                    self.pending_hide = PendingHide::None;
+                    MainEventsAction::Stop
+                }
+                PendingHide::WaitingForHideVerification { verify_after, .. }
+                    if now < verify_after =>
+                {
+                    MainEventsAction::None
+                }
+                PendingHide::WaitingForHideVerification { retry_count: 0, .. } => {
+                    self.pending_hide = PendingHide::WaitingForHideVerification {
+                        retry_count: 1,
+                        verify_after: now + HIDE_VERIFICATION_DELAY,
+                    };
+                    MainEventsAction::Hide
+                }
+                PendingHide::WaitingForHideVerification { .. } => {
+                    self.pending_hide = PendingHide::None;
+                    MainEventsAction::Stop
+                }
+                _ => MainEventsAction::None,
             }
         }
 
@@ -99,24 +160,65 @@ mod macos {
             self.pending_hide = PendingHide::None;
         }
 
-        fn has_pending_hide(&self) -> bool {
+        fn has_pending_main_events_work(&self) -> bool {
             !matches!(self.pending_hide, PendingHide::None)
+        }
+
+        fn is_waiting_for_fullscreen_exit(&self) -> bool {
+            matches!(
+                self.pending_hide,
+                PendingHide::WaitingForFullscreenExit { .. }
+            )
+        }
+
+        fn is_waiting_for_hide_verification(&self) -> bool {
+            matches!(
+                self.pending_hide,
+                PendingHide::WaitingForHideVerification { .. }
+            )
         }
     }
 
     static MAIN_WINDOW_CLOSE_STATE: LazyLock<Mutex<MainWindowCloseState>> =
         LazyLock::new(|| Mutex::new(MainWindowCloseState::new()));
 
-    fn read_fullscreen_state(result: tauri::Result<bool>, log_errors: bool) -> Option<bool> {
-        match result {
-            Ok(is_fullscreen) => Some(is_fullscreen),
-            Err(error) => {
-                if log_errors {
-                    eprintln!("failed to query macOS main window fullscreen state: {error}");
-                }
-                None
+    define_class!(
+        #[unsafe(super = NSObject)]
+        #[thread_kind = MainThreadOnly]
+        struct FullscreenExitObserver;
+
+        unsafe impl NSObjectProtocol for FullscreenExitObserver {}
+
+        impl FullscreenExitObserver {
+            #[unsafe(method(handleWindowDidExitFullScreen:))]
+            fn handle_window_did_exit_fullscreen(&self, notification: &NSNotification) {
+                handle_fullscreen_exit_notification(notification);
             }
         }
+    );
+
+    impl FullscreenExitObserver {
+        fn new(mtm: MainThreadMarker) -> Retained<Self> {
+            unsafe { msg_send![Self::alloc(mtm), init] }
+        }
+    }
+
+    thread_local! {
+        static FULLSCREEN_EXIT_OBSERVER: RefCell<Option<Retained<FullscreenExitObserver>>> = const { RefCell::new(None) };
+    }
+
+    fn fullscreen_exit_observer(mtm: MainThreadMarker) -> Retained<FullscreenExitObserver> {
+        FULLSCREEN_EXIT_OBSERVER.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            slot.get_or_insert_with(|| FullscreenExitObserver::new(mtm))
+                .clone()
+        })
+    }
+
+    fn is_native_fullscreen(ns_window: &NSWindow) -> bool {
+        ns_window
+            .styleMask()
+            .contains(NSWindowStyleMask::FullScreen)
     }
 
     fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
@@ -132,24 +234,195 @@ mod macos {
         MAIN_WINDOW_CLOSE_STATE.lock().reset();
     }
 
-    fn hide_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
-        let app_handle_for_closure = app_handle.clone();
+    fn clear_fullscreen_exit_flow(mtm: Option<MainThreadMarker>) {
+        if let Some(mtm) = mtm {
+            unregister_fullscreen_exit_observer(mtm);
+        }
+        reset_pending_hide();
+    }
 
-        if let Err(error) = app_handle.run_on_main_thread(move || {
-            let mtm = MainThreadMarker::new().expect("window hide should run on main thread");
-            let app = NSApp(mtm);
+    fn register_fullscreen_exit_observer(mtm: MainThreadMarker, ns_window: &NSWindow) {
+        let observer = fullscreen_exit_observer(mtm);
+        let center = NSNotificationCenter::defaultCenter();
 
-            if let Some(window) = app_handle_for_closure.get_webview_window(MAIN_WINDOW_LABEL) {
-                if let Ok(ns_window) = window.ns_window() {
-                    let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
-                    ns_window.orderOut(None);
-                }
+        unsafe {
+            center.removeObserver_name_object(
+                &*observer,
+                Some(NSWindowDidExitFullScreenNotification),
+                Some(ns_window),
+            );
+            center.addObserver_selector_name_object(
+                &*observer,
+                sel!(handleWindowDidExitFullScreen:),
+                Some(NSWindowDidExitFullScreenNotification),
+                Some(ns_window),
+            );
+        }
+    }
+
+    fn unregister_fullscreen_exit_observer(mtm: MainThreadMarker) {
+        let observer = fullscreen_exit_observer(mtm);
+        let center = NSNotificationCenter::defaultCenter();
+
+        unsafe {
+            center.removeObserver(&*observer);
+        }
+    }
+
+    fn request_exit_fullscreen(ns_window: &NSWindow) {
+        ns_window.toggleFullScreen(None);
+    }
+
+    fn hide_window_once(mtm: MainThreadMarker, ns_window: &NSWindow) {
+        let app = NSApp(mtm);
+        ns_window.orderOut(None);
+        app.hide(None);
+    }
+
+    fn request_hide_once(ns_window: &NSWindow) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            eprintln!("macOS window hide must run on the main thread");
+            clear_fullscreen_exit_flow(None);
+            return;
+        };
+
+        hide_window_once(mtm, ns_window);
+    }
+
+    fn advance_hide_verification_on_main_thread<R: tauri::Runtime>(
+        app_handle: &tauri::AppHandle<R>,
+    ) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            eprintln!("macOS hide verification must run on the main thread");
+            clear_fullscreen_exit_flow(None);
+            return;
+        };
+
+        let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) else {
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let Ok(ns_window) = window.ns_window() else {
+            eprintln!("failed to access native macOS main window during hide verification");
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
+        match MAIN_WINDOW_CLOSE_STATE
+            .lock()
+            .on_hide_result(!ns_window.isVisible(), Instant::now())
+        {
+            MainEventsAction::None => {}
+            MainEventsAction::Hide => {
+                hide_window_once(mtm, ns_window);
             }
+            MainEventsAction::Stop => {}
+            MainEventsAction::RetryExitFullscreen => {}
+        }
+    }
 
-            app.hide(None);
-        }) {
-            eprintln!("failed to dispatch macOS window hide to main thread: {error}");
-            reset_pending_hide();
+    fn handle_fullscreen_exit_notification(notification: &NSNotification) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            eprintln!("macOS fullscreen exit notification must run on the main thread");
+            clear_fullscreen_exit_flow(None);
+            return;
+        };
+
+        let Some(object) = notification.object() else {
+            eprintln!("missing window object on macOS fullscreen exit notification");
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let Ok(window) = object.downcast::<NSWindow>() else {
+            eprintln!("unexpected macOS fullscreen exit notification object");
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        unregister_fullscreen_exit_observer(mtm);
+
+        if MAIN_WINDOW_CLOSE_STATE
+            .lock()
+            .on_fullscreen_exit_succeeded(Instant::now())
+            == MainEventsAction::Hide
+        {
+            request_hide_once(&window);
+        }
+    }
+
+    fn handle_close_request_on_main_thread<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            eprintln!("macOS close handling must run on the main thread");
+            clear_fullscreen_exit_flow(None);
+            return;
+        };
+
+        let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) else {
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let Ok(ns_window) = window.ns_window() else {
+            eprintln!("failed to access native macOS main window");
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
+
+        match MAIN_WINDOW_CLOSE_STATE
+            .lock()
+            .on_close_requested(is_native_fullscreen(ns_window), Instant::now())
+        {
+            CloseRequestAction::None => {}
+            CloseRequestAction::HideImmediately => {
+                request_hide_once(ns_window);
+            }
+            CloseRequestAction::ExitFullscreenThenHide => {
+                register_fullscreen_exit_observer(mtm, ns_window);
+                request_exit_fullscreen(ns_window);
+            }
+        }
+    }
+
+    fn advance_fullscreen_exit_on_main_thread<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+        let Some(mtm) = MainThreadMarker::new() else {
+            eprintln!("macOS fullscreen progress check must run on the main thread");
+            clear_fullscreen_exit_flow(None);
+            return;
+        };
+
+        let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) else {
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let Ok(ns_window) = window.ns_window() else {
+            eprintln!("failed to access native macOS main window during fullscreen progress check");
+            clear_fullscreen_exit_flow(Some(mtm));
+            return;
+        };
+
+        let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
+        match MAIN_WINDOW_CLOSE_STATE
+            .lock()
+            .on_fullscreen_exit_progress(is_native_fullscreen(ns_window), Instant::now())
+        {
+            MainEventsAction::None => {}
+            MainEventsAction::RetryExitFullscreen => {
+                register_fullscreen_exit_observer(mtm, ns_window);
+                request_exit_fullscreen(ns_window);
+            }
+            MainEventsAction::Hide => {
+                unregister_fullscreen_exit_observer(mtm);
+                request_hide_once(ns_window);
+            }
+            MainEventsAction::Stop => {
+                unregister_fullscreen_exit_observer(mtm);
+            }
         }
     }
 
@@ -162,27 +435,14 @@ mod macos {
         }
 
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            let close_action =
-                MAIN_WINDOW_CLOSE_STATE
-                    .lock()
-                    .on_close_requested(read_fullscreen_state(
-                        window.is_fullscreen(),
-                        true,
-                    ), Instant::now());
+            api.prevent_close();
 
-            match close_action {
-                CloseRequestAction::HideImmediately => {
-                    api.prevent_close();
-                    hide_main_window(&window.app_handle());
-                }
-                CloseRequestAction::ExitFullscreenThenHide => {
-                    api.prevent_close();
-                    if let Err(error) = window.set_fullscreen(false) {
-                        eprintln!(
-                            "failed to exit macOS fullscreen during close request: {error}"
-                        );
-                    }
-                }
+            let app_handle = window.app_handle().clone();
+            if let Err(error) = window.app_handle().run_on_main_thread(move || {
+                handle_close_request_on_main_thread(&app_handle);
+            }) {
+                eprintln!("failed to dispatch macOS close handling to main thread: {error}");
+                clear_fullscreen_exit_flow(None);
             }
         }
     }
@@ -193,25 +453,27 @@ mod macos {
     ) {
         match event {
             tauri::RunEvent::MainEventsCleared => {
-                if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
-                    let now = Instant::now();
-                    let needs_fullscreen_state = MAIN_WINDOW_CLOSE_STATE.lock().has_pending_hide();
-                    let fullscreen_state = if needs_fullscreen_state {
-                        read_fullscreen_state(window.is_fullscreen(), false)
-                    } else {
-                        None
-                    };
-                    let action = MAIN_WINDOW_CLOSE_STATE
-                        .lock()
-                        .on_main_events_cleared(fullscreen_state, now);
-                    match action {
-                        MainEventsAction::None => {}
-                        MainEventsAction::RetryExitFullscreen => {
-                            let _ = window.set_fullscreen(false);
+                let pending_work = {
+                    let state = MAIN_WINDOW_CLOSE_STATE.lock();
+                    (
+                        state.has_pending_main_events_work(),
+                        state.is_waiting_for_fullscreen_exit(),
+                        state.is_waiting_for_hide_verification(),
+                    )
+                };
+
+                if pending_work.0 {
+                    let app_handle = app_handle.clone();
+                    let app_handle_for_closure = app_handle.clone();
+                    if let Err(error) = app_handle.run_on_main_thread(move || {
+                        if pending_work.1 {
+                            advance_fullscreen_exit_on_main_thread(&app_handle_for_closure);
+                        } else if pending_work.2 {
+                            advance_hide_verification_on_main_thread(&app_handle_for_closure);
                         }
-                        MainEventsAction::Hide => {
-                            hide_main_window(app_handle);
-                        }
+                    }) {
+                        eprintln!("failed to dispatch macOS close-flow progress check to main thread: {error}");
+                        clear_fullscreen_exit_flow(None);
                     }
                 }
             }

--- a/src-tauri/src/window_behavior.rs
+++ b/src-tauri/src/window_behavior.rs
@@ -1,49 +1,241 @@
 #[cfg(target_os = "macos")]
-use tauri::Manager;
+mod macos {
+    use std::{
+        sync::LazyLock,
+        time::{Duration, Instant},
+    };
 
-const MAIN_WINDOW_LABEL: &str = "main";
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApp, NSWindow};
+    use parking_lot::Mutex;
+    use tauri::Manager;
 
-#[cfg(target_os = "macos")]
-fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
-    if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
-        if window.show().is_err() {
-            return;
-        }
-        let _ = window.set_focus();
+    const MAIN_WINDOW_LABEL: &str = "main";
+    const FULLSCREEN_HIDE_DELAY: Duration = Duration::from_millis(500);
+    const FULLSCREEN_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum CloseRequestAction {
+        HideImmediately,
+        ExitFullscreenThenHide,
     }
-}
 
-#[cfg(target_os = "macos")]
-pub(crate) fn handle_window_event<R: tauri::Runtime>(
-    window: &tauri::Window<R>,
-    event: &tauri::WindowEvent,
-) {
-    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MainEventsAction {
+        None,
+        RetryExitFullscreen,
+        Hide,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum PendingHide {
+        None,
+        WaitingForFullscreenExitUntil(Instant),
+        WaitingUntil(Instant),
+    }
+
+    #[derive(Debug)]
+    struct MainWindowCloseState {
+        pending_hide: PendingHide,
+    }
+
+    impl MainWindowCloseState {
+        fn new() -> Self {
+            Self {
+                pending_hide: PendingHide::None,
+            }
+        }
+
+        fn on_close_requested(
+            &mut self,
+            is_fullscreen: Option<bool>,
+            now: Instant,
+        ) -> CloseRequestAction {
+            match is_fullscreen {
+                Some(false) => {
+                    self.pending_hide = PendingHide::None;
+                    CloseRequestAction::HideImmediately
+                }
+                Some(true) | None => {
+                    self.pending_hide =
+                        PendingHide::WaitingForFullscreenExitUntil(now + FULLSCREEN_EXIT_TIMEOUT);
+                    CloseRequestAction::ExitFullscreenThenHide
+                }
+            }
+        }
+
+        fn on_main_events_cleared(
+            &mut self,
+            is_fullscreen: Option<bool>,
+            now: Instant,
+        ) -> MainEventsAction {
+            match self.pending_hide {
+                PendingHide::None => MainEventsAction::None,
+                PendingHide::WaitingForFullscreenExitUntil(deadline) => match is_fullscreen {
+                    Some(false) => {
+                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
+                        MainEventsAction::None
+                    }
+                    Some(true) if now < deadline => MainEventsAction::None,
+                    Some(true) => {
+                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
+                        MainEventsAction::RetryExitFullscreen
+                    }
+                    None if now >= deadline => {
+                        self.pending_hide = PendingHide::WaitingUntil(now + FULLSCREEN_HIDE_DELAY);
+                        MainEventsAction::None
+                    }
+                    None => MainEventsAction::None,
+                },
+                PendingHide::WaitingUntil(deadline) if now < deadline => MainEventsAction::None,
+                PendingHide::WaitingUntil(_) => {
+                    self.pending_hide = PendingHide::None;
+                    MainEventsAction::Hide
+                }
+            }
+        }
+
+        fn reset(&mut self) {
+            self.pending_hide = PendingHide::None;
+        }
+
+        fn has_pending_hide(&self) -> bool {
+            !matches!(self.pending_hide, PendingHide::None)
+        }
+    }
+
+    static MAIN_WINDOW_CLOSE_STATE: LazyLock<Mutex<MainWindowCloseState>> =
+        LazyLock::new(|| Mutex::new(MainWindowCloseState::new()));
+
+    fn read_fullscreen_state(result: tauri::Result<bool>, log_errors: bool) -> Option<bool> {
+        match result {
+            Ok(is_fullscreen) => Some(is_fullscreen),
+            Err(error) => {
+                if log_errors {
+                    eprintln!("failed to query macOS main window fullscreen state: {error}");
+                }
+                None
+            }
+        }
+    }
+
+    fn restore_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+        if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
+            if window.show().is_err() {
+                return;
+            }
+            let _ = window.set_focus();
+        }
+    }
+
+    fn reset_pending_hide() {
+        MAIN_WINDOW_CLOSE_STATE.lock().reset();
+    }
+
+    fn hide_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+        let app_handle_for_closure = app_handle.clone();
+
+        if let Err(error) = app_handle.run_on_main_thread(move || {
+            let mtm = MainThreadMarker::new().expect("window hide should run on main thread");
+            let app = NSApp(mtm);
+
+            if let Some(window) = app_handle_for_closure.get_webview_window(MAIN_WINDOW_LABEL) {
+                if let Ok(ns_window) = window.ns_window() {
+                    let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
+                    ns_window.orderOut(None);
+                }
+            }
+
+            app.hide(None);
+        }) {
+            eprintln!("failed to dispatch macOS window hide to main thread: {error}");
+            reset_pending_hide();
+        }
+    }
+
+    pub(crate) fn handle_window_event<R: tauri::Runtime>(
+        window: &tauri::Window<R>,
+        event: &tauri::WindowEvent,
+    ) {
         if window.label() != MAIN_WINDOW_LABEL {
             return;
         }
-        api.prevent_close();
-        let _ = window.hide();
+
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            let close_action =
+                MAIN_WINDOW_CLOSE_STATE
+                    .lock()
+                    .on_close_requested(read_fullscreen_state(
+                        window.is_fullscreen(),
+                        true,
+                    ), Instant::now());
+
+            match close_action {
+                CloseRequestAction::HideImmediately => {
+                    api.prevent_close();
+                    hide_main_window(&window.app_handle());
+                }
+                CloseRequestAction::ExitFullscreenThenHide => {
+                    api.prevent_close();
+                    if let Err(error) = window.set_fullscreen(false) {
+                        eprintln!(
+                            "failed to exit macOS fullscreen during close request: {error}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn handle_run_event<R: tauri::Runtime>(
+        app_handle: &tauri::AppHandle<R>,
+        event: tauri::RunEvent,
+    ) {
+        match event {
+            tauri::RunEvent::MainEventsCleared => {
+                if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
+                    let now = Instant::now();
+                    let needs_fullscreen_state = MAIN_WINDOW_CLOSE_STATE.lock().has_pending_hide();
+                    let fullscreen_state = if needs_fullscreen_state {
+                        read_fullscreen_state(window.is_fullscreen(), false)
+                    } else {
+                        None
+                    };
+                    let action = MAIN_WINDOW_CLOSE_STATE
+                        .lock()
+                        .on_main_events_cleared(fullscreen_state, now);
+                    match action {
+                        MainEventsAction::None => {}
+                        MainEventsAction::RetryExitFullscreen => {
+                            let _ = window.set_fullscreen(false);
+                        }
+                        MainEventsAction::Hide => {
+                            hide_main_window(app_handle);
+                        }
+                    }
+                }
+            }
+            tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } => {
+                if !has_visible_windows {
+                    restore_main_window(app_handle);
+                }
+            }
+            _ => {}
+        }
     }
 }
+
+#[cfg(target_os = "macos")]
+pub(crate) use macos::{handle_run_event, handle_window_event};
 
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn handle_window_event<R: tauri::Runtime>(
     _window: &tauri::Window<R>,
     _event: &tauri::WindowEvent,
 ) {
-}
-
-#[cfg(target_os = "macos")]
-pub(crate) fn handle_run_event<R: tauri::Runtime>(
-    app_handle: &tauri::AppHandle<R>,
-    event: tauri::RunEvent,
-) {
-    if let tauri::RunEvent::Reopen { has_visible_windows, .. } = event {
-        if !has_visible_windows {
-            restore_main_window(app_handle);
-        }
-    }
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary

  Fix macOS window close behavior when the main window is in native fullscreen.

  Previously, `cmd+w` on macOS hid the app in normal window mode, but could leave the app in a bad state when the user had entered native fullscreen from the green traffic-light button. This change keeps the
  existing hide-on-close behavior for the main window while making fullscreen close handling safer.

  ## Changes

  - intercept macOS main-window `CloseRequested`
  - keep normal-window close behavior as hide instead of quitting
  - when the main window is in native fullscreen:
    - prevent immediate close
    - request exit from fullscreen first
    - wait for fullscreen exit to settle
    - then hide the app via native AppKit APIs
  - restore the main window on macOS app reopen
  - narrow `objc2-app-kit` features to only what this behavior needs

  ## Files

  - `src-tauri/src/window_behavior.rs`
  - `src-tauri/Cargo.toml`
  - `src-tauri/Cargo.lock`

  ## Verification

  Ran:

  ```bash
  cargo test --manifest-path src-tauri/Cargo.toml --lib -- --nocapture

  Result:

  - 15 tests passed
  - 0 failed

  ## Notes

  - This change is macOS-specific.
  - It uses native AppKit hide behavior through NSApp / NSWindow because Tauri does not expose a dedicated fullscreen-exit-complete event for this exact workflow.