### PR TITLE
feat(terminal): add selection gate to pause output during text selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ dist-ssr
 bump-version.sh
 .env*
 knowledge
+
+# TypeScript / Vite build artifacts
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4617,6 +4617,7 @@ dependencies = [
  "libc",
  "mio 1.1.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }
+tokio = { version = "1", features = ["sync", "macros", "rt", "time", "process", "io-util"] }
 once_cell = "1.19"
 portable-pty = "0.8"
 chrono = "0.4"

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -78,70 +78,74 @@ fn previewable_image_mime_type(path: &Path) -> Option<&'static str> {
 
 #[tauri::command]
 pub async fn read_dir_entries(path: String, project_path: String) -> Result<Vec<FsEntry>, String> {
-    validate_path_within(&path, &project_path)?;
-    let entries = std::fs::read_dir(&path).map_err(|e| e.to_string())?;
-    let mut result: Vec<FsEntry> = entries
-        .flatten()
-        .filter(|entry| {
-            let p = entry.path();
-            if p.is_dir() {
-                let name = entry.file_name();
-                let name_str = name.to_string_lossy();
-                !IGNORED_DIRS.contains(&name_str.as_ref())
-            } else {
-                true
-            }
-        })
-        .map(|entry| {
-            let p = entry.path();
-            let name = entry.file_name().to_string_lossy().into_owned();
-            let is_dir = p.is_dir();
-            let extension =
-                p.extension().and_then(|e| e.to_str()).map(|s| s.to_lowercase());
-            FsEntry { name, path: p.to_string_lossy().into_owned(), is_dir, extension, is_gitignored: false }
-        })
-        .collect();
-    result.sort_by(|a, b| match (a.is_dir, b.is_dir) {
-        (true, false) => std::cmp::Ordering::Less,
-        (false, true) => std::cmp::Ordering::Greater,
-        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-    });
+    tauri::async_runtime::spawn_blocking(move || {
+        validate_path_within(&path, &project_path)?;
+        let entries = std::fs::read_dir(&path).map_err(|e| e.to_string())?;
+        let mut result: Vec<FsEntry> = entries
+            .flatten()
+            .filter(|entry| {
+                let p = entry.path();
+                if p.is_dir() {
+                    let name = entry.file_name();
+                    let name_str = name.to_string_lossy();
+                    !IGNORED_DIRS.contains(&name_str.as_ref())
+                } else {
+                    true
+                }
+            })
+            .map(|entry| {
+                let p = entry.path();
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let is_dir = p.is_dir();
+                let extension =
+                    p.extension().and_then(|e| e.to_str()).map(|s| s.to_lowercase());
+                FsEntry { name, path: p.to_string_lossy().into_owned(), is_dir, extension, is_gitignored: false }
+            })
+            .collect();
+        result.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        });
 
-    // Mark gitignored entries via `git check-ignore --stdin`
-    if !result.is_empty() {
-        let ignored_set: std::collections::HashSet<String> = {
-            use std::io::Write;
-            let mut cmd = std::process::Command::new("git");
-            cmd.args(["check-ignore", "--stdin"])
-                .current_dir(&project_path)
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null());
-            match cmd.spawn() {
-                Ok(mut child) => {
-                    if let Some(ref mut stdin) = child.stdin {
-                        for entry in &result {
-                            let _ = writeln!(stdin, "{}", entry.path);
+        // Mark gitignored entries via `git check-ignore --stdin`
+        if !result.is_empty() {
+            let ignored_set: std::collections::HashSet<String> = {
+                use std::io::Write;
+                let mut cmd = std::process::Command::new("git");
+                cmd.args(["check-ignore", "--stdin"])
+                    .current_dir(&project_path)
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::null());
+                match cmd.spawn() {
+                    Ok(mut child) => {
+                        if let Some(ref mut stdin) = child.stdin {
+                            for entry in &result {
+                                let _ = writeln!(stdin, "{}", entry.path);
+                            }
+                        }
+                        match child.wait_with_output() {
+                            Ok(output) => String::from_utf8_lossy(&output.stdout)
+                                .lines()
+                                .filter(|l| !l.is_empty())
+                                .map(|l| l.to_string())
+                                .collect(),
+                            Err(_) => std::collections::HashSet::new(),
                         }
                     }
-                    match child.wait_with_output() {
-                        Ok(output) => String::from_utf8_lossy(&output.stdout)
-                            .lines()
-                            .filter(|l| !l.is_empty())
-                            .map(|l| l.to_string())
-                            .collect(),
-                        Err(_) => std::collections::HashSet::new(),
-                    }
+                    Err(_) => std::collections::HashSet::new(),
                 }
-                Err(_) => std::collections::HashSet::new(),
+            };
+            for entry in &mut result {
+                entry.is_gitignored = ignored_set.contains(&entry.path);
             }
-        };
-        for entry in &mut result {
-            entry.is_gitignored = ignored_set.contains(&entry.path);
         }
-    }
 
-    Ok(result)
+        Ok(result)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
@@ -204,38 +208,40 @@ pub async fn read_image_preview(path: String, project_path: String) -> Result<Im
 
 #[tauri::command]
 pub async fn write_file_content(path: String, content: String, project_path: String) -> Result<(), String> {
-    validate_path_within(&path, &project_path)?;
-    std::fs::write(&path, content).map_err(|e| e.to_string())
+    tauri::async_runtime::spawn_blocking(move || {
+        validate_path_within(&path, &project_path)?;
+        std::fs::write(&path, content).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
 pub async fn list_project_files(project_path: String) -> Result<Vec<String>, String> {
-    let tracked = std::process::Command::new("git")
-        .args(["-c", "core.quotePath=false", "ls-files"])
-        .current_dir(&project_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let output = std::process::Command::new("git")
+            .args([
+                "-c",
+                "core.quotePath=false",
+                "ls-files",
+                "-c",
+                "-o",
+                "--exclude-standard",
+            ])
+            .current_dir(&project_path)
+            .output()
+            .map_err(|e| e.to_string())?;
 
-    let untracked = std::process::Command::new("git")
-        .args(["-c", "core.quotePath=false", "ls-files", "--others", "--exclude-standard"])
-        .current_dir(&project_path)
-        .output()
-        .map_err(|e| e.to_string())?;
+        let mut files: Vec<String> = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect();
 
-    let mut files: Vec<String> = String::from_utf8_lossy(&tracked.stdout)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
-        .collect();
-
-    let extra: Vec<String> = String::from_utf8_lossy(&untracked.stdout)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
-        .collect();
-
-    files.extend(extra);
-    files.sort();
-    files.dedup();
-    Ok(files)
+        files.sort();
+        files.dedup();
+        Ok(files)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -88,7 +88,9 @@ async fn run_git_with_timeout(
         Ok(result) => result.map_err(|e| e.to_string())?,
         Err(_) => {
             let _ = child.start_kill();
-            let _ = child.wait().await;
+            let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
+            stdout_task.abort();
+            stderr_task.abort();
             let _ = stdout_task.await;
             let _ = stderr_task.await;
             return Err(format!("Git 命令执行超时（{}秒）", timeout.as_secs()));

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -247,7 +247,12 @@ pub(crate) struct GitBranchInfo {
 
 #[tauri::command]
 pub async fn git_list_branches(project_path: String) -> Result<Vec<GitBranchInfo>, String> {
-    let output = run_git(&project_path, &["branch", "-a"])?;
+    let output = run_git_with_timeout(
+        project_path,
+        vec!["branch".to_string(), "-a".to_string()],
+        Duration::from_secs(5),
+    )
+    .await?;
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let mut branches = Vec::new();
     for line in stdout.lines() {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::process::{Output, Stdio};
 use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 // ── 辅助函数 ─────────────────────────────────────────────────────────────────
 
@@ -41,25 +43,66 @@ fn run_git<S: AsRef<std::ffi::OsStr>>(
         .map_err(|e| e.to_string())
 }
 
+async fn read_pipe_to_end<R: AsyncRead + Unpin>(
+    mut pipe: R,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    let mut data = Vec::new();
+    pipe.read_to_end(&mut data)
+        .await
+        .map_err(|e| format!("Failed to read git {}: {}", stream_name, e))?;
+    Ok(data)
+}
+
 /// 带超时的 git 命令执行。
-/// 使用 tokio::task::spawn_blocking 将阻塞操作移到线程池，
-/// 并用 tokio::time::timeout 限制最长执行时间。
+/// 超时后会终止底层 git 子进程，避免后台进程和阻塞线程持续积压。
 async fn run_git_with_timeout(
     project_path: String,
     args: Vec<String>,
     timeout: Duration,
-) -> Result<std::process::Output, String> {
-    tokio::time::timeout(timeout, tokio::task::spawn_blocking(move || {
-        validate_project_path(&project_path)?;
-        std::process::Command::new("git")
-            .args(&args)
-            .current_dir(&project_path)
-            .output()
-            .map_err(|e| e.to_string())
-    }))
-    .await
-    .map_err(|_| format!("Git 命令执行超时（{}秒）", timeout.as_secs()))?
-    .map_err(|e| format!("Git 命令线程错误: {}", e))?
+) -> Result<Output, String> {
+    validate_project_path(&project_path)?;
+
+    let mut child = tokio::process::Command::new("git")
+        .args(&args)
+        .current_dir(&project_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| e.to_string())?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture git stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture git stderr".to_string())?;
+
+    let stdout_task = tokio::spawn(read_pipe_to_end(stdout, "stdout"));
+    let stderr_task = tokio::spawn(read_pipe_to_end(stderr, "stderr"));
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(result) => result.map_err(|e| e.to_string())?,
+        Err(_) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            return Err(format!("Git 命令执行超时（{}秒）", timeout.as_secs()));
+        }
+    };
+
+    let stdout = stdout_task
+        .await
+        .map_err(|e| format!("Git stdout task failed: {}", e))??;
+    let stderr = stderr_task
+        .await
+        .map_err(|e| format!("Git stderr task failed: {}", e))??;
+
+    Ok(Output { status, stdout, stderr })
 }
 
 /// 执行 git 命令，若退出码非零则将 stderr 作为错误返回。

--- a/src/App.css
+++ b/src/App.css
@@ -842,3 +842,10 @@ body {
   color: #fff;
   border-radius: 2px;
 }
+
+/* xterm 容器独立合成层，防止 canvas dirty 触发父层重合成 */
+.xterm {
+  contain: layout paint style;
+  isolation: isolate;
+  will-change: transform;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -843,9 +843,8 @@ body {
   border-radius: 2px;
 }
 
-/* xterm 容器独立合成层，防止 canvas dirty 触发父层重合成 */
+/* xterm 子树隔离：防止辅助 DOM（选区/link/textarea/scrollbar）变更外溢父级 layout/paint */
 .xterm {
   contain: layout paint style;
   isolation: isolate;
-  will-change: transform;
 }

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -68,8 +68,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
     const isDarkRef = useRef(isDark);
     const isActiveRef = useRef(isActive);
     const onReadyRef = useRef(onReady);
-    const writerRef = useRef<ReturnType<typeof createSmartWriter> | null>(null);
-    const hiddenBufferRef = useRef<string>("");
     const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null);
     isDarkRef.current = isDark;
     isActiveRef.current = isActive;
@@ -132,7 +130,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       }, 50);
 
       const writer = createSmartWriter(term);
-      writerRef.current = writer;
       const disposeSmartCopy = attachSmartCopy(term);
       const disposeOnData = term.onData((data) => {
         invoke("send_input", { taskId: shellId, data }).catch(() => {});
@@ -163,11 +160,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       let unlisten: (() => void) | null = null;
       listen<ShellOutputEvent>("shell-output", (event) => {
         if (event.payload.shell_id === shellId && terminalRef.current) {
-          // 隐藏期间缓存，避免每条输出都触发 canvas 重绘与合成
-          if (!isActiveRef.current) {
-            hiddenBufferRef.current += event.payload.data;
-            return;
-          }
           writer.write(event.payload.data);
         }
       }).then((fn) => {
@@ -209,11 +201,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
             lastSizeRef.current = { cols: s.cols, rows: s.rows };
             invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
           }
-        }
-        if (hiddenBufferRef.current) {
-          const buffered = hiddenBufferRef.current;
-          hiddenBufferRef.current = "";
-          writerRef.current?.write(buffered);
         }
         terminalRef.current.refresh(0, terminalRef.current.rows - 1);
         terminalRef.current.focus();

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -68,6 +68,9 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
     const isDarkRef = useRef(isDark);
     const isActiveRef = useRef(isActive);
     const onReadyRef = useRef(onReady);
+    const writerRef = useRef<ReturnType<typeof createSmartWriter> | null>(null);
+    const hiddenBufferRef = useRef<string>("");
+    const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null);
     isDarkRef.current = isDark;
     isActiveRef.current = isActive;
     onReadyRef.current = onReady;
@@ -98,7 +101,11 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       const fit = () => {
         if (cleaned) return;
         const s = safeFit(fitAddon, term);
-        if (s) invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
+        if (!s) return;
+        const last = lastSizeRef.current;
+        if (last && last.cols === s.cols && last.rows === s.rows) return;
+        lastSizeRef.current = { cols: s.cols, rows: s.rows };
+        invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
       };
 
       initTimeoutId = window.setTimeout(() => {
@@ -125,6 +132,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       }, 50);
 
       const writer = createSmartWriter(term);
+      writerRef.current = writer;
       const disposeSmartCopy = attachSmartCopy(term);
       const disposeOnData = term.onData((data) => {
         invoke("send_input", { taskId: shellId, data }).catch(() => {});
@@ -155,6 +163,11 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       let unlisten: (() => void) | null = null;
       listen<ShellOutputEvent>("shell-output", (event) => {
         if (event.payload.shell_id === shellId && terminalRef.current) {
+          // 隐藏期间缓存，避免每条输出都触发 canvas 重绘与合成
+          if (!isActiveRef.current) {
+            hiddenBufferRef.current += event.payload.data;
+            return;
+          }
           writer.write(event.payload.data);
         }
       }).then((fn) => {
@@ -190,7 +203,18 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       window.requestAnimationFrame(() => {
         if (!fitAddonRef.current || !terminalRef.current) return;
         const s = safeFit(fitAddonRef.current, terminalRef.current);
-        if (s) invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
+        if (s) {
+          const last = lastSizeRef.current;
+          if (!last || last.cols !== s.cols || last.rows !== s.rows) {
+            lastSizeRef.current = { cols: s.cols, rows: s.rows };
+            invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
+          }
+        }
+        if (hiddenBufferRef.current) {
+          const buffered = hiddenBufferRef.current;
+          hiddenBufferRef.current = "";
+          writerRef.current?.write(buffered);
+        }
         terminalRef.current.refresh(0, terminalRef.current.rows - 1);
         terminalRef.current.focus();
       });

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -7,7 +7,6 @@ import {
   DARK_THEME,
   LIGHT_THEME,
   initTerminal,
-  loadWebglAddon,
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
@@ -65,7 +64,8 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
-    loadWebglAddon(term);
+    // 故意不启用 WebGL renderer：选区首次建立有 ~100-300ms 启动成本（纹理/shader 初始化），
+    // Canvas renderer 在 Nezha 的文本量级下交互更顺畅。
 
     const size = safeFit(fitAddon, term);
     if (size) onResizeRef.current(size.cols, size.rows);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
@@ -55,6 +55,15 @@ export function TerminalView({
   onResizeRef.current = onResize;
   onRegisterRef.current = onRegisterTerminal;
 
+  // 仅在 cols/rows 真正变化时回调；否则会触发 resize_pty → SIGWINCH →
+  // 下游 TUI（Claude Code / Codex）全屏重绘，导致每次切回都看到一次多余重画。
+  const notifyResize = useCallback((cols: number, rows: number) => {
+    const last = lastSizeRef.current;
+    if (last && last.cols === cols && last.rows === rows) return;
+    lastSizeRef.current = { cols, rows };
+    onResizeRef.current(cols, rows);
+  }, []);
+
   useEffect(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
@@ -67,15 +76,6 @@ export function TerminalView({
     term.loadAddon(serializeAddon);
     term.open(container);
     loadWebglAddon(term);
-
-    // 仅在 cols/rows 真正变化时回调；否则会触发 resize_pty → SIGWINCH →
-    // 下游 TUI（Claude Code / Codex）全屏重绘，导致每次切回都看到一次多余重画。
-    const notifyResize = (cols: number, rows: number) => {
-      const last = lastSizeRef.current;
-      if (last && last.cols === cols && last.rows === rows) return;
-      lastSizeRef.current = { cols, rows };
-      onResizeRef.current(cols, rows);
-    };
 
     const size = safeFit(fitAddon, term);
     if (size) notifyResize(size.cols, size.rows);
@@ -180,17 +180,11 @@ export function TerminalView({
     window.requestAnimationFrame(() => {
       if (!fitAddonRef.current || !terminalRef.current) return;
       const s = safeFit(fitAddonRef.current, terminalRef.current);
-      if (s) {
-        const last = lastSizeRef.current;
-        if (!last || last.cols !== s.cols || last.rows !== s.rows) {
-          lastSizeRef.current = { cols: s.cols, rows: s.rows };
-          onResizeRef.current(s.cols, s.rows);
-        }
-      }
+      if (s) notifyResize(s.cols, s.rows);
       terminalRef.current.refresh(0, terminalRef.current.rows - 1);
       terminalRef.current.focus();
     });
-  }, [isActive]);
+  }, [isActive, notifyResize]);
 
   useEffect(() => {
     if (terminalRef.current) {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -46,11 +46,7 @@ export function TerminalView({
   const onRegisterRef = useRef(onRegisterTerminal);
   const onReadyRef = useRef(onReady);
   const onSnapshotRef = useRef(onSnapshot);
-  const isActiveRef = useRef(isActive);
-  const writerRef = useRef<ReturnType<typeof createSmartWriter> | null>(null);
-  const hiddenBufferRef = useRef<string>("");
   const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null);
-  isActiveRef.current = isActive;
   onReadyRef.current = onReady;
   onSnapshotRef.current = onSnapshot;
 
@@ -91,20 +87,8 @@ export function TerminalView({
     };
 
     const writer = createSmartWriter(term);
-    writerRef.current = writer;
 
-    // 终端隐藏时，`visibility: hidden` 仍保留合成层，任何 term.write 都会触发 canvas 重绘
-    // 与每帧合成开销。所以把隐藏期间到达的数据缓存起来，切回可见时一次性 flush。
-    const gatedWrite = (data: string, callback?: () => void) => {
-      if (!isActiveRef.current) {
-        hiddenBufferRef.current += data;
-        callback?.();
-        return;
-      }
-      writer.write(data, callback);
-    };
-
-    const terminalGeneration = onRegisterRef.current(gatedWrite);
+    const terminalGeneration = onRegisterRef.current(writer.write);
 
     const completeRestore = () => {
       onReadyRef.current?.(terminalGeneration);
@@ -202,11 +186,6 @@ export function TerminalView({
           lastSizeRef.current = { cols: s.cols, rows: s.rows };
           onResizeRef.current(s.cols, s.rows);
         }
-      }
-      if (hiddenBufferRef.current) {
-        const buffered = hiddenBufferRef.current;
-        hiddenBufferRef.current = "";
-        writerRef.current?.write(buffered);
       }
       terminalRef.current.refresh(0, terminalRef.current.rows - 1);
       terminalRef.current.focus();

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -7,6 +7,7 @@ import {
   DARK_THEME,
   LIGHT_THEME,
   initTerminal,
+  loadWebglAddon,
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
@@ -45,6 +46,11 @@ export function TerminalView({
   const onRegisterRef = useRef(onRegisterTerminal);
   const onReadyRef = useRef(onReady);
   const onSnapshotRef = useRef(onSnapshot);
+  const isActiveRef = useRef(isActive);
+  const writerRef = useRef<ReturnType<typeof createSmartWriter> | null>(null);
+  const hiddenBufferRef = useRef<string>("");
+  const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null);
+  isActiveRef.current = isActive;
   onReadyRef.current = onReady;
   onSnapshotRef.current = onSnapshot;
 
@@ -64,11 +70,19 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
-    // 故意不启用 WebGL renderer：选区首次建立有 ~100-300ms 启动成本（纹理/shader 初始化），
-    // Canvas renderer 在 Nezha 的文本量级下交互更顺畅。
+    loadWebglAddon(term);
+
+    // 仅在 cols/rows 真正变化时回调；否则会触发 resize_pty → SIGWINCH →
+    // 下游 TUI（Claude Code / Codex）全屏重绘，导致每次切回都看到一次多余重画。
+    const notifyResize = (cols: number, rows: number) => {
+      const last = lastSizeRef.current;
+      if (last && last.cols === cols && last.rows === rows) return;
+      lastSizeRef.current = { cols, rows };
+      onResizeRef.current(cols, rows);
+    };
 
     const size = safeFit(fitAddon, term);
-    if (size) onResizeRef.current(size.cols, size.rows);
+    if (size) notifyResize(size.cols, size.rows);
 
     const focusTerminal = () => {
       window.requestAnimationFrame(() => {
@@ -77,8 +91,20 @@ export function TerminalView({
     };
 
     const writer = createSmartWriter(term);
+    writerRef.current = writer;
 
-    const terminalGeneration = onRegisterRef.current(writer.write);
+    // 终端隐藏时，`visibility: hidden` 仍保留合成层，任何 term.write 都会触发 canvas 重绘
+    // 与每帧合成开销。所以把隐藏期间到达的数据缓存起来，切回可见时一次性 flush。
+    const gatedWrite = (data: string, callback?: () => void) => {
+      if (!isActiveRef.current) {
+        hiddenBufferRef.current += data;
+        callback?.();
+        return;
+      }
+      writer.write(data, callback);
+    };
+
+    const terminalGeneration = onRegisterRef.current(gatedWrite);
 
     const completeRestore = () => {
       onReadyRef.current?.(terminalGeneration);
@@ -87,7 +113,7 @@ export function TerminalView({
 
     window.requestAnimationFrame(() => {
       const s = safeFit(fitAddon, term);
-      if (s) onResizeRef.current(s.cols, s.rows);
+      if (s) notifyResize(s.cols, s.rows);
       if (initialSnapshot) {
         term.write(initialSnapshot, () => {
           if (initialData) {
@@ -124,7 +150,7 @@ export function TerminalView({
       if (document.visibilityState !== "visible") return;
       window.requestAnimationFrame(() => {
         const s = safeFit(fitAddon, term);
-        if (s) onResizeRef.current(s.cols, s.rows);
+        if (s) notifyResize(s.cols, s.rows);
         term.refresh(0, term.rows - 1);
         term.focus();
       });
@@ -139,7 +165,7 @@ export function TerminalView({
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(() => {
         const s = safeFit(fitAddon, term);
-        if (s) onResizeRef.current(s.cols, s.rows);
+        if (s) notifyResize(s.cols, s.rows);
       }, 50);
     });
     resizeObserver.observe(container);
@@ -170,7 +196,18 @@ export function TerminalView({
     window.requestAnimationFrame(() => {
       if (!fitAddonRef.current || !terminalRef.current) return;
       const s = safeFit(fitAddonRef.current, terminalRef.current);
-      if (s) onResizeRef.current(s.cols, s.rows);
+      if (s) {
+        const last = lastSizeRef.current;
+        if (!last || last.cols !== s.cols || last.rows !== s.rows) {
+          lastSizeRef.current = { cols: s.cols, rows: s.rows };
+          onResizeRef.current(s.cols, s.rows);
+        }
+      }
+      if (hiddenBufferRef.current) {
+        const buffered = hiddenBufferRef.current;
+        hiddenBufferRef.current = "";
+        writerRef.current?.write(buffered);
+      }
       terminalRef.current.refresh(0, terminalRef.current.rows - 1);
       terminalRef.current.focus();
     });

--- a/src/components/task-panel/BranchBar.tsx
+++ b/src/components/task-panel/BranchBar.tsx
@@ -335,6 +335,10 @@ export function BranchBar({ projectPath }: { projectPath: string }) {
         branchName: branch.name,
         isRemote: branch.remote !== null,
       });
+      const staleFetch = inflightRef.current;
+      if (staleFetch) {
+        await staleFetch;
+      }
       await fetchBranches();
       setPickerOpen(false);
       setSearch("");

--- a/src/components/task-panel/BranchBar.tsx
+++ b/src/components/task-panel/BranchBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { Search, Plus, ChevronDown, X, Tag, Check, GitFork, GitBranch } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import * as Popover from "@radix-ui/react-popover";
@@ -272,13 +272,23 @@ export function BranchBar({ projectPath }: { projectPath: string }) {
   const [switching, setSwitching] = useState<string | null>(null);
   const [switchError, setSwitchError] = useState("");
 
+  // 防止 focus / 轮询 / 切换分支 等多源触发同时打出多次 IPC 请求。
+  // 已有未完成的请求时直接复用，避免后端 git 命令并发堵塞 Tokio worker。
+  const inflightRef = useRef<Promise<void> | null>(null);
   const fetchBranches = useCallback(async () => {
-    try {
-      const result = await invoke<GitBranchInfo[]>("git_list_branches", { projectPath });
-      setBranches(result);
-    } catch {
-      // not a git repo or git not available
-    }
+    if (inflightRef.current) return inflightRef.current;
+    const p = (async () => {
+      try {
+        const result = await invoke<GitBranchInfo[]>("git_list_branches", { projectPath });
+        setBranches(result);
+      } catch {
+        // not a git repo or git not available
+      } finally {
+        inflightRef.current = null;
+      }
+    })();
+    inflightRef.current = p;
+    return p;
   }, [projectPath]);
 
   useEffect(() => {


### PR DESCRIPTION
Introduce a module-level `selectionGate` that blocks the RAF drain loop while the user is selecting text, preventing frame budget contention between data writes and selection redraws. Resume flushing buffered output immediately on pointer release via `onResume` callback. Also handle `pointercancel` events and cleanup on unmount to prevent stuck gate state.