### PR TITLE
feat: support drag reordering in project rail

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -1,4 +1,5 @@
 use base64::Engine;
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
@@ -17,6 +18,16 @@ pub(crate) struct ImagePreviewData {
     data_url: String,
     mime_type: String,
     byte_length: u64,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProjectFileSearchEntry {
+    name: String,
+    path: String,
+    relative_path: String,
+    extension: Option<String>,
+    is_gitignored: bool,
 }
 
 const IGNORED_DIRS: &[&str] = &[
@@ -75,6 +86,62 @@ fn previewable_image_mime_type(path: &Path) -> Option<&'static str> {
         "svg" => Some("image/svg+xml"),
         _ => None,
     }
+}
+
+fn collect_project_file_search_entries(
+    root: &Path,
+    current_dir: &Path,
+    visited_dirs: &mut HashSet<std::path::PathBuf>,
+    result: &mut Vec<ProjectFileSearchEntry>,
+) -> Result<(), String> {
+    let canonical_dir = match current_dir.canonicalize() {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
+    if !canonical_dir.starts_with(root) || !visited_dirs.insert(canonical_dir.clone()) {
+        return Ok(());
+    }
+
+    let entries = match std::fs::read_dir(current_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+
+        if path.is_dir() {
+            if IGNORED_DIRS.contains(&name.as_str()) {
+                continue;
+            }
+            collect_project_file_search_entries(root, &path, visited_dirs, result)?;
+            continue;
+        }
+
+        let extension = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_lowercase());
+        let relative_path = match path.strip_prefix(root) {
+            Ok(relative_path) => relative_path.to_string_lossy().replace('\\', "/"),
+            Err(_) => continue,
+        };
+
+        result.push(ProjectFileSearchEntry {
+            name,
+            path: path.to_string_lossy().into_owned(),
+            relative_path,
+            extension,
+            is_gitignored: false,
+        });
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -294,6 +361,60 @@ pub async fn list_project_files(project_path: String) -> Result<Vec<String>, Str
         files.sort();
         files.dedup();
         Ok(files)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn list_project_file_search_entries(
+    project_path: String,
+) -> Result<Vec<ProjectFileSearchEntry>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = validate_path_within(&project_path, &project_path)?;
+        let mut result = Vec::new();
+        let mut visited_dirs = HashSet::new();
+        collect_project_file_search_entries(&root, &root, &mut visited_dirs, &mut result)?;
+        result.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+
+        if !result.is_empty() {
+            let ignored_set: std::collections::HashSet<String> = {
+                use std::io::Write;
+
+                let mut cmd = std::process::Command::new("git");
+                crate::subprocess::configure_background_command(&mut cmd);
+                cmd.args(["check-ignore", "--stdin"])
+                    .current_dir(&root)
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::null());
+
+                match cmd.spawn() {
+                    Ok(mut child) => {
+                        if let Some(ref mut stdin) = child.stdin {
+                            for entry in &result {
+                                let _ = writeln!(stdin, "{}", entry.path);
+                            }
+                        }
+                        match child.wait_with_output() {
+                            Ok(output) => String::from_utf8_lossy(&output.stdout)
+                                .lines()
+                                .filter(|line| !line.is_empty())
+                                .map(|line| line.to_string())
+                                .collect(),
+                            Err(_) => std::collections::HashSet::new(),
+                        }
+                    }
+                    Err(_) => std::collections::HashSet::new(),
+                }
+            };
+
+            for entry in &mut result {
+                entry.is_gitignored = ignored_set.contains(&entry.path);
+            }
+        }
+
+        Ok(result)
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             fs::read_image_preview,
             fs::write_file_content,
             fs::list_project_files,
+            fs::list_project_file_search_entries,
             git::generate_commit_message,
             git::git_status,
             git::git_list_branches,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { open as openDialog, confirm } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -37,6 +37,19 @@ function persistProjectTasks(projectId: string, allTasks: Task[], onError: (msg:
   });
 }
 
+function reorderProjects(projects: Project[], draggedProjectId: string, targetProjectId: string) {
+  if (draggedProjectId === targetProjectId) return projects;
+
+  const sourceIndex = projects.findIndex((project) => project.id === draggedProjectId);
+  const targetIndex = projects.findIndex((project) => project.id === targetProjectId);
+  if (sourceIndex === -1 || targetIndex === -1) return projects;
+
+  const next = [...projects];
+  const [draggedProject] = next.splice(sourceIndex, 1);
+  next.splice(targetIndex, 0, draggedProject);
+  return next;
+}
+
 interface ProjectViewState {
   selectedTaskId: string | null;
   isNewTask: boolean;
@@ -67,6 +80,7 @@ function App() {
   const [projectViews, setProjectViews] = useState<Record<string, ProjectViewState>>({});
   const [mountedProjectIds, setMountedProjectIds] = useState<string[]>([]);
   const [taskRunCounts, setTaskRunCounts] = useState<Record<string, number>>({});
+  const projectsRef = useRef<Project[]>([]);
 
   const tm = useTerminalManager();
 
@@ -97,6 +111,10 @@ function App() {
   function getProjectView(projectId: string): ProjectViewState {
     return projectViews[projectId] ?? createDefaultProjectViewState();
   }
+
+  useEffect(() => {
+    projectsRef.current = projects;
+  }, [projects]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
@@ -201,6 +219,22 @@ function App() {
       showToast(`Failed to initialize project config: ${String(e)}`, "warning");
     });
   }
+
+  const handleReorderProjects = useCallback(
+    (draggedProjectId: string, targetProjectId: string) => {
+      setProjects((prev) => {
+        const next = reorderProjects(prev, draggedProjectId, targetProjectId);
+        if (next === prev) return prev;
+        projectsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handlePersistProjectOrder = useCallback(() => {
+    persistProjects(projectsRef.current, showToast);
+  }, [showToast]);
 
   function handleBack() {
     setActiveProject(null);
@@ -508,7 +542,7 @@ function App() {
     [projects],
   );
   const railProjects = useMemo(
-    () => [...projects].sort((a, b) => Number(a.id) - Number(b.id)),
+    () => [...projects],
     [projects],
   );
   const mountedProjects = useMemo(
@@ -564,6 +598,8 @@ function App() {
               onSnapshot={tm.handleSnapshot}
               onBack={handleBack}
               onSwitchProject={handleProjectClick}
+              onReorderProjects={handleReorderProjects}
+              onPersistProjectOrder={handlePersistProjectOrder}
               onOpen={handleOpen}
               isDark={isDark}
               themeMode={themeMode}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, useDeferredValue } from "react";
 import { useCancellableInvoke } from "../hooks/useCancellableInvoke";
 import { invoke } from "@tauri-apps/api/core";
-import { ChevronRight, ChevronDown, RotateCcw } from "lucide-react";
+import { ChevronRight, ChevronDown, RotateCcw, Search, Filter } from "lucide-react";
 import { getFileColor } from "../utils";
 import { useToast } from "./Toast";
 
@@ -16,6 +16,21 @@ interface FsEntry {
 interface TreeNode extends FsEntry {
   children: TreeNode[] | null; // null = not loaded yet
   expanded: boolean;
+}
+
+interface SearchFileEntry {
+  name: string;
+  path: string;
+  relativePath: string;
+  extension?: string;
+  isGitignored: boolean;
+}
+
+interface IndexedSearchFileEntry extends SearchFileEntry {
+  normalizedName: string;
+  normalizedPath: string;
+  nameTokens: string[];
+  pathTokens: string[];
 }
 
 const GITIGNORED_COLOR = "#6b7280";
@@ -122,30 +137,74 @@ function flattenVisible(nodes: TreeNode[]): Array<{ node: TreeNode; depth: numbe
   return result;
 }
 
-function TreeItem({
-  node,
+function splitSearchTokens(value: string) {
+  return value
+    .split(/[/\\._\-\s]+/)
+    .flatMap((part) => part.split(/(?=[A-Z])/))
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function hasCjk(value: string) {
+  return /[\u3400-\u9fff]/.test(value);
+}
+
+function getSearchRank(entry: IndexedSearchFileEntry, query: string) {
+  const nameStartsWith = entry.normalizedName.startsWith(query);
+  const nameTokenStartsWith = entry.nameTokens.some((token) => token.startsWith(query));
+  const pathTokenStartsWith = entry.pathTokens.some((token) => token.startsWith(query));
+  const allowLooseSubstring = query.length >= 3 || (query.length >= 2 && hasCjk(query));
+  const nameIncludes = allowLooseSubstring && entry.normalizedName.includes(query);
+  const pathIncludes = query.includes("/") && entry.normalizedPath.includes(query);
+
+  if (nameStartsWith) return 0;
+  if (nameTokenStartsWith) return 1;
+  if (pathTokenStartsWith) return 2;
+  if (nameIncludes) return 3;
+  if (pathIncludes) return 4;
+  return null;
+}
+
+function FileRow({
+  name,
+  path,
   depth,
+  extension,
+  isDir = false,
+  expanded,
+  isGitignored,
   selectedPath,
   contextPath,
+  trailingLabel,
+  title,
   onSelect,
-  onToggle,
   onContextMenu,
+  leadingSlot,
 }: {
-  node: TreeNode;
+  name: string;
+  path: string;
   depth: number;
+  extension?: string;
+  isDir?: boolean;
+  expanded?: boolean;
+  isGitignored?: boolean;
   selectedPath: string | null;
   contextPath: string | null;
-  onSelect: (node: TreeNode) => void;
-  onToggle: (path: string) => void;
-  onContextMenu: (e: React.MouseEvent, node: TreeNode) => void;
+  trailingLabel?: string;
+  title?: string;
+  onSelect: (path: string, name: string) => void;
+  onContextMenu: (e: React.MouseEvent, path: string) => void;
+  leadingSlot?: React.ReactNode;
 }) {
-  const isSelected = selectedPath === node.path;
-  const isContextTarget = contextPath === node.path;
+  const isSelected = selectedPath === path;
+  const isContextTarget = contextPath === path;
   const isHighlighted = isSelected || isContextTarget;
+
   return (
     <div
-      onClick={() => (node.is_dir ? onToggle(node.path) : onSelect(node))}
-      onContextMenu={(e) => onContextMenu(e, node)}
+      onClick={() => onSelect(path, name)}
+      onContextMenu={(e) => onContextMenu(e, path)}
+      title={title}
       style={{
         display: "flex",
         alignItems: "center",
@@ -180,19 +239,19 @@ function TreeItem({
           color: "var(--text-hint)",
         }}
       >
-        {node.is_dir && (node.expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />)}
+        {leadingSlot}
       </span>
       <FileIcon
-        name={node.name}
-        ext={node.extension}
-        isDir={node.is_dir}
-        expanded={node.expanded}
-        isGitignored={node.is_gitignored}
+        name={name}
+        ext={extension}
+        isDir={isDir}
+        expanded={expanded}
+        isGitignored={isGitignored}
       />
       <span
         style={{
           fontSize: 12.5,
-          color: node.is_gitignored ? GITIGNORED_COLOR : "var(--text-primary)",
+          color: isGitignored ? GITIGNORED_COLOR : "var(--text-primary)",
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
@@ -200,9 +259,70 @@ function TreeItem({
           fontFamily: "var(--font-ui)",
         }}
       >
-        {node.name}
+        {name}
       </span>
+      {trailingLabel && trailingLabel !== name && (
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-hint)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flexShrink: 1,
+            minWidth: 0,
+            maxWidth: "34%",
+            textAlign: "right",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {trailingLabel}
+        </span>
+      )}
     </div>
+  );
+}
+
+function TreeItem({
+  node,
+  depth,
+  selectedPath,
+  contextPath,
+  onSelect,
+  onToggle,
+  onContextMenu,
+}: {
+  node: TreeNode;
+  depth: number;
+  selectedPath: string | null;
+  contextPath: string | null;
+  onSelect: (node: TreeNode) => void;
+  onToggle: (path: string) => void;
+  onContextMenu: (e: React.MouseEvent, path: string) => void;
+}) {
+  return (
+    <FileRow
+      name={node.name}
+      path={node.path}
+      depth={depth}
+      extension={node.extension}
+      isDir={node.is_dir}
+      expanded={node.expanded}
+      isGitignored={node.is_gitignored}
+      selectedPath={selectedPath}
+      contextPath={contextPath}
+      onSelect={(path, _name) => {
+        if (node.is_dir) {
+          onToggle(path);
+          return;
+        }
+        onSelect(node);
+      }}
+      onContextMenu={onContextMenu}
+      leadingSlot={
+        node.is_dir ? (node.expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />) : undefined
+      }
+    />
   );
 }
 
@@ -312,10 +432,15 @@ export function FileExplorer({
   width?: number;
 }) {
   const [nodes, setNodes] = useState<TreeNode[]>([]);
+  const [projectFiles, setProjectFiles] = useState<SearchFileEntry[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const [loading, setLoading] = useState(true);
+  const [searchIndexLoading, setSearchIndexLoading] = useState(true);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(500);
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const deferredSearch = useDeferredValue(normalizedSearch);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { showToast } = useToast();
   const [ctxMenu, setCtxMenu] = useState<{
@@ -324,10 +449,10 @@ export function FileExplorer({
     path: string;
   } | null>(null);
 
-  const handleContextMenu = useCallback((e: React.MouseEvent, node: TreeNode) => {
+  const handleContextMenu = useCallback((e: React.MouseEvent, path: string) => {
     e.preventDefault();
     e.stopPropagation();
-    setCtxMenu({ x: e.clientX, y: e.clientY, path: node.path });
+    setCtxMenu({ x: e.clientX, y: e.clientY, path });
   }, []);
 
   const closeCtxMenu = useCallback(() => setCtxMenu(null), []);
@@ -364,6 +489,8 @@ export function FileExplorer({
   const { safeInvoke, isCancelled } = useCancellableInvoke();
   const nodesRef = useRef<TreeNode[]>([]);
   const refreshIdRef = useRef(0);
+  const searchRefreshIdRef = useRef(0);
+  const searchIndexStatusRef = useRef<"idle" | "loading" | "loaded">("idle");
 
   useEffect(() => {
     nodesRef.current = nodes;
@@ -372,6 +499,40 @@ export function FileExplorer({
   const readEntries = useCallback(
     (path: string) => safeInvoke<FsEntry[]>("read_dir_entries", { path, projectPath }),
     [projectPath, safeInvoke],
+  );
+
+  const loadProjectFiles = useCallback(
+    async (showLoading = false) => {
+      const refreshId = searchRefreshIdRef.current + 1;
+      searchRefreshIdRef.current = refreshId;
+      searchIndexStatusRef.current = "loading";
+      if (showLoading) setSearchIndexLoading(true);
+      try {
+        const files = await safeInvoke<SearchFileEntry[]>("list_project_file_search_entries", {
+          projectPath,
+        });
+        if (files === null || refreshId !== searchRefreshIdRef.current) return;
+        searchIndexStatusRef.current = "loaded";
+        setProjectFiles(files);
+      } catch {
+        if (!isCancelled() && refreshId === searchRefreshIdRef.current) {
+          searchIndexStatusRef.current = "idle";
+        }
+      } finally {
+        if (!isCancelled() && refreshId === searchRefreshIdRef.current) {
+          setSearchIndexLoading(false);
+        }
+      }
+    },
+    [isCancelled, projectPath, safeInvoke],
+  );
+
+  const refreshSearchIndex = useCallback(
+    async (showLoading = false) => {
+      if (!normalizedSearch) return;
+      await loadProjectFiles(showLoading);
+    },
+    [loadProjectFiles, normalizedSearch],
   );
 
   const refresh = useCallback(
@@ -402,11 +563,31 @@ export function FileExplorer({
   }, [active, projectPath, refresh]);
 
   useEffect(() => {
+    searchRefreshIdRef.current += 1;
+    searchIndexStatusRef.current = "idle";
+    setProjectFiles([]);
+    setSearchIndexLoading(false);
+  }, [active, projectPath]);
+
+  useEffect(() => {
+    if (!normalizedSearch) {
+      searchRefreshIdRef.current += 1;
+      searchIndexStatusRef.current = "idle";
+      setProjectFiles([]);
+      setSearchIndexLoading(false);
+      return;
+    }
+    if (!active || searchIndexStatusRef.current !== "idle") return;
+    void loadProjectFiles(true);
+  }, [active, loadProjectFiles, normalizedSearch]);
+
+  useEffect(() => {
     if (!active) return;
 
     const handleVisibilityRefresh = () => {
       if (document.visibilityState !== "visible") return;
       void refresh();
+      void refreshSearchIndex();
     };
 
     const timer = window.setInterval(() => {
@@ -422,7 +603,7 @@ export function FileExplorer({
       window.removeEventListener("focus", handleVisibilityRefresh);
       document.removeEventListener("visibilitychange", handleVisibilityRefresh);
     };
-  }, [active, refresh]);
+  }, [active, refresh, refreshSearchIndex]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -434,11 +615,44 @@ export function FileExplorer({
   }, []);
 
   const flat = useMemo(() => flattenVisible(nodes), [nodes]);
+  const indexedProjectFiles = useMemo<IndexedSearchFileEntry[]>(
+    () =>
+      projectFiles.map((entry) => ({
+        ...entry,
+        normalizedName: entry.name.toLowerCase(),
+        normalizedPath: entry.relativePath.toLowerCase(),
+        nameTokens: splitSearchTokens(entry.name),
+        pathTokens: splitSearchTokens(entry.relativePath),
+      })),
+    [projectFiles],
+  );
+  const searchResults = useMemo(() => {
+    if (!deferredSearch) return [];
+
+    return indexedProjectFiles
+      .map((entry) => {
+        const rank = getSearchRank(entry, deferredSearch);
+        return {
+          ...entry,
+          rank,
+        };
+      })
+      .filter((item) => item.rank !== null)
+      .sort((a, b) => {
+        if (a.rank !== b.rank) return (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER);
+        const aNameLengthDelta = a.name.length - deferredSearch.length;
+        const bNameLengthDelta = b.name.length - deferredSearch.length;
+        if (aNameLengthDelta !== bNameLengthDelta) return aNameLengthDelta - bNameLengthDelta;
+        return a.relativePath.localeCompare(b.relativePath);
+      });
+  }, [deferredSearch, indexedProjectFiles]);
 
   const OVERSCAN = 5;
+  const totalRows = normalizedSearch ? searchResults.length : flat.length;
+  const showSearchLoading = normalizedSearch && searchIndexLoading;
   const startIdx = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
   const endIdx = Math.min(
-    flat.length - 1,
+    totalRows - 1,
     Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + OVERSCAN,
   );
 
@@ -477,6 +691,14 @@ export function FileExplorer({
     (node: TreeNode) => {
       setSelectedPath(node.path);
       onFileSelect(node.path, node.name);
+    },
+    [onFileSelect],
+  );
+
+  const handleSearchResultSelect = useCallback(
+    (path: string, name: string) => {
+      setSelectedPath(path);
+      onFileSelect(path, name);
     },
     [onFileSelect],
   );
@@ -596,7 +818,12 @@ export function FileExplorer({
           Files
         </span>
         <button
-          onClick={() => void refresh()}
+          onClick={() => {
+            void refresh();
+            if (normalizedSearch) {
+              void loadProjectFiles(true);
+            }
+          }}
           title="Refresh"
           style={{
             background: "none",
@@ -621,37 +848,72 @@ export function FileExplorer({
           <RotateCcw size={13} />
         </button>
       </div>
-      {/* Project root label */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "6px 8px 3px 20px",
-          fontSize: 12.5,
-          fontWeight: 600,
-          color: "var(--text-primary)",
-        }}
-      >
-        <span
+      <div style={{ padding: "8px 10px 4px", flexShrink: 0 }}>
+        <div
           style={{
-            width: 5,
-            height: 14,
-            borderRadius: 2,
-            background: "var(--accent)",
-            flexShrink: 0,
-            display: "inline-block",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "5px 9px",
+            background: "var(--bg-card)",
+            border: "1px solid var(--border-dim)",
+            borderRadius: 6,
           }}
-        />
-        {projectName}
+        >
+          <Search size={12} color="var(--text-hint)" />
+          <input
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setScrollTop(0);
+              scrollRef.current?.scrollTo({ top: 0 });
+            }}
+            placeholder="Search files"
+            style={{
+              flex: 1,
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              color: "var(--text-primary)",
+              fontSize: 12,
+            }}
+          />
+          <Filter size={12} color="var(--text-hint)" />
+        </div>
       </div>
+      {/* Project root label */}
+      {!normalizedSearch && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "6px 8px 3px 20px",
+            fontSize: 12.5,
+            fontWeight: 600,
+            color: "var(--text-primary)",
+          }}
+        >
+          <span
+            style={{
+              width: 5,
+              height: 14,
+              borderRadius: 2,
+              background: "var(--accent)",
+              flexShrink: 0,
+              display: "inline-block",
+            }}
+          />
+          {projectName}
+        </div>
+      )}
       {/* Tree */}
       <div
         ref={scrollRef}
         onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
         style={{ flex: 1, overflowY: "auto", position: "relative" }}
       >
-        {loading ? (
+        {loading || showSearchLoading ? (
           <div
             style={{
               padding: "16px 12px",
@@ -662,7 +924,7 @@ export function FileExplorer({
           >
             Loading...
           </div>
-        ) : flat.length === 0 ? (
+        ) : totalRows === 0 ? (
           <div
             style={{
               padding: "16px 12px",
@@ -671,30 +933,55 @@ export function FileExplorer({
               textAlign: "center",
             }}
           >
-            Empty directory
+            {normalizedSearch ? "No files found" : "Empty directory"}
           </div>
         ) : (
-          <div style={{ height: flat.length * ROW_HEIGHT + 12, position: "relative" }}>
-            {flat.slice(startIdx, endIdx + 1).map(({ node, depth }, i) => (
-              <div
-                key={node.path}
-                style={{
-                  position: "absolute",
-                  top: (startIdx + i) * ROW_HEIGHT + 2,
-                  width: "100%",
-                }}
-              >
-                <TreeItem
-                  node={node}
-                  depth={depth}
-                  selectedPath={selectedPath}
-                  contextPath={ctxMenu?.path ?? null}
-                  onSelect={handleSelect}
-                  onToggle={handleToggle}
-                  onContextMenu={handleContextMenu}
-                />
-              </div>
-            ))}
+          <div style={{ height: totalRows * ROW_HEIGHT + 12, position: "relative" }}>
+            {normalizedSearch
+              ? searchResults.slice(startIdx, endIdx + 1).map((item, i) => (
+                  <div
+                    key={item.path}
+                    style={{
+                      position: "absolute",
+                      top: (startIdx + i) * ROW_HEIGHT + 2,
+                      width: "100%",
+                    }}
+                  >
+                    <FileRow
+                      name={item.name}
+                      path={item.path}
+                      depth={0}
+                      extension={item.extension}
+                      isGitignored={item.isGitignored}
+                      selectedPath={selectedPath}
+                      contextPath={ctxMenu?.path ?? null}
+                      trailingLabel={item.relativePath}
+                      title={item.relativePath}
+                      onSelect={handleSearchResultSelect}
+                      onContextMenu={handleContextMenu}
+                    />
+                  </div>
+                ))
+              : flat.slice(startIdx, endIdx + 1).map(({ node, depth }, i) => (
+                  <div
+                    key={node.path}
+                    style={{
+                      position: "absolute",
+                      top: (startIdx + i) * ROW_HEIGHT + 2,
+                      width: "100%",
+                    }}
+                  >
+                    <TreeItem
+                      node={node}
+                      depth={depth}
+                      selectedPath={selectedPath}
+                      contextPath={ctxMenu?.path ?? null}
+                      onSelect={handleSelect}
+                      onToggle={handleToggle}
+                      onContextMenu={handleContextMenu}
+                    />
+                  </div>
+                ))}
           </div>
         )}
       </div>

--- a/src/components/ProjectPage.tsx
+++ b/src/components/ProjectPage.tsx
@@ -52,6 +52,8 @@ export function ProjectPage({
   onSnapshot,
   onBack,
   onSwitchProject,
+  onReorderProjects,
+  onPersistProjectOrder,
   onOpen,
   isDark,
   themeMode,
@@ -98,6 +100,8 @@ export function ProjectPage({
   onSnapshot: (taskId: string, snapshot: string) => void;
   onBack: () => void;
   onSwitchProject: (project: Project) => void;
+  onReorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
+  onPersistProjectOrder: () => void;
   onOpen: () => void;
   isDark: boolean;
   themeMode: ThemeMode;
@@ -202,6 +206,8 @@ export function ProjectPage({
         allTasks={tasks}
         activeProjectId={project.id}
         onSwitch={onSwitchProject}
+        onReorderProjects={onReorderProjects}
+        onPersistProjectOrder={onPersistProjectOrder}
         onOpen={onOpen}
       />
       <TaskPanel

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { Plus, ChevronsRight } from "lucide-react";
 import type { Project, Task } from "../types";
 import { ProjectAvatar } from "./ProjectAvatar";
@@ -36,19 +36,56 @@ function RailItem({
   project,
   isActive,
   status,
+  isDragging,
+  isDragTarget,
   onSwitch,
+  onPointerDown,
+  onMount,
 }: {
   project: Project;
   isActive: boolean;
   status: ProjectStatus;
+  isDragging: boolean;
+  isDragTarget: boolean;
   onSwitch: (p: Project) => void;
+  onPointerDown: (
+    projectId: string,
+    event: {
+      x: number;
+      y: number;
+      offsetX: number;
+      offsetY: number;
+      width: number;
+      height: number;
+      pointerId: number;
+      node: HTMLButtonElement;
+    },
+  ) => void;
+  onMount: (projectId: string, node: HTMLButtonElement | null) => void;
 }) {
   const [hov, setHov] = useState(false);
+  const transform = isDragging ? "scale(0.92)" : isDragTarget ? "scale(1.04)" : "translate3d(0, 0, 0)";
 
   return (
     <button
+      ref={(node) => onMount(project.id, node)}
       title={project.name}
+      data-project-rail-id={project.id}
       onClick={() => onSwitch(project)}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        const rect = event.currentTarget.getBoundingClientRect();
+        onPointerDown(project.id, {
+          x: event.clientX,
+          y: event.clientY,
+          offsetX: event.clientX - rect.left,
+          offsetY: event.clientY - rect.top,
+          width: rect.width,
+          height: rect.height,
+          pointerId: event.pointerId,
+          node: event.currentTarget,
+        });
+      }}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       className={isActive ? "rail-active" : undefined}
@@ -59,23 +96,74 @@ function RailItem({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "none",
+        background: isDragTarget ? "var(--accent-subtle)" : "none",
         border: "none",
         borderRadius: 10,
-        cursor: isActive ? "default" : "pointer",
+        cursor: isDragging ? "grabbing" : isActive ? "grab" : "pointer",
         padding: 0,
+        touchAction: "none",
+        userSelect: "none",
+        opacity: isDragging ? 0.16 : 1,
+        transform,
+        zIndex: isDragging ? 1 : 0,
+        boxShadow: isDragTarget ? "0 4px 12px rgba(0,0,0,0.12)" : "none",
         outline: isActive
           ? "2px solid var(--accent)"
+          : isDragTarget
+            ? "2px solid var(--accent)"
           : hov
             ? "2px solid var(--border-medium)"
             : "2px solid transparent",
         outlineOffset: 1,
-        transition: isActive ? "none" : "outline-color 0.12s",
+        transition:
+          "transform 0.18s ease, outline-color 0.12s, opacity 0.12s, background 0.12s, box-shadow 0.16s",
       }}
     >
       <ProjectAvatar name={project.name} size={28} />
       <StatusBadge status={status} />
     </button>
+  );
+}
+
+function DragPreview({
+  project,
+  status,
+  x,
+  y,
+  width,
+  height,
+}: {
+  project: Project;
+  status: ProjectStatus;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: x,
+        top: y,
+        width,
+        height,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: 10,
+        background: "color-mix(in srgb, var(--bg-sidebar) 84%, white 16%)",
+        boxShadow: "0 12px 28px rgba(0,0,0,0.24)",
+        transform: "scale(1.08)",
+        pointerEvents: "none",
+        zIndex: 999,
+      }}
+    >
+      <div style={{ position: "relative", width: 28, height: 28 }}>
+        <ProjectAvatar name={project.name} size={28} />
+        <StatusBadge status={status} />
+      </div>
+    </div>
   );
 }
 
@@ -213,17 +301,153 @@ export function ProjectRail({
   allTasks,
   activeProjectId,
   onSwitch,
+  onReorderProjects,
+  onPersistProjectOrder,
   onOpen,
 }: {
   projects: Project[];
   allTasks: Task[];
   activeProjectId: string;
   onSwitch: (project: Project) => void;
+  onReorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
+  onPersistProjectOrder: () => void;
   onOpen: () => void;
 }) {
   const [addHov, setAddHov] = useState(false);
   const [expandHov, setExpandHov] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [draggedProjectId, setDraggedProjectId] = useState<string | null>(null);
+  const [dragTargetProjectId, setDragTargetProjectId] = useState<string | null>(null);
+  const [dragPreview, setDragPreview] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+  const draggedProjectIdRef = useRef<string | null>(null);
+  const lastHoverProjectIdRef = useRef<string | null>(null);
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const dragMovedRef = useRef(false);
+  const reorderChangedRef = useRef(false);
+  const suppressClickRef = useRef(false);
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const previousTopsRef = useRef<Map<string, number>>(new Map());
+  const activePointerIdRef = useRef<number | null>(null);
+  const activePointerNodeRef = useRef<HTMLButtonElement | null>(null);
+
+  const clearDragState = useCallback(() => {
+    const activePointerId = activePointerIdRef.current;
+    const activePointerNode = activePointerNodeRef.current;
+    if (activePointerId !== null && activePointerNode?.hasPointerCapture(activePointerId)) {
+      activePointerNode.releasePointerCapture(activePointerId);
+    }
+    activePointerIdRef.current = null;
+    activePointerNodeRef.current = null;
+
+    if (reorderChangedRef.current) {
+      onPersistProjectOrder();
+    }
+    if (dragMovedRef.current) {
+      suppressClickRef.current = true;
+      window.setTimeout(() => {
+        suppressClickRef.current = false;
+      }, 0);
+    }
+    draggedProjectIdRef.current = null;
+    lastHoverProjectIdRef.current = null;
+    pointerStartRef.current = null;
+    reorderChangedRef.current = false;
+    setDragPreview(null);
+    setDraggedProjectId(null);
+    setDragTargetProjectId(null);
+    dragMovedRef.current = false;
+  }, [onPersistProjectOrder]);
+
+  function getProjectIdAtPoint(x: number, y: number): string | null {
+    const element = document.elementFromPoint(x, y);
+    const item = element?.closest("[data-project-rail-id]");
+    return item instanceof HTMLElement ? (item.dataset.projectRailId ?? null) : null;
+  }
+
+  useEffect(() => {
+    if (!draggedProjectId) return;
+
+    function handlePointerMove(event: PointerEvent) {
+      const start = pointerStartRef.current;
+      const draggedId = draggedProjectIdRef.current;
+      if (!start || !draggedId) return;
+
+      const distance = Math.hypot(event.clientX - start.x, event.clientY - start.y);
+      if (distance < 4) return;
+      dragMovedRef.current = true;
+
+      setDragPreview((prev) =>
+        prev
+          ? {
+              ...prev,
+              x: event.clientX - prev.offsetX,
+              y: event.clientY - prev.offsetY,
+            }
+          : prev,
+      );
+
+      const targetProjectId = getProjectIdAtPoint(event.clientX, event.clientY);
+      if (!targetProjectId || targetProjectId === lastHoverProjectIdRef.current) return;
+
+      lastHoverProjectIdRef.current = targetProjectId;
+      setDragTargetProjectId(targetProjectId);
+      if (targetProjectId !== draggedId) {
+        reorderChangedRef.current = true;
+        onReorderProjects(draggedId, targetProjectId);
+      }
+    }
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", clearDragState);
+    document.addEventListener("pointercancel", clearDragState);
+    window.addEventListener("blur", clearDragState);
+
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", clearDragState);
+      document.removeEventListener("pointercancel", clearDragState);
+      window.removeEventListener("blur", clearDragState);
+    };
+  }, [clearDragState, draggedProjectId, onReorderProjects]);
+
+  useLayoutEffect(() => {
+    const nextTops = new Map<string, number>();
+
+    projects.forEach((project) => {
+      const node = itemRefs.current[project.id];
+      if (!node) return;
+
+      const top = node.getBoundingClientRect().top;
+      nextTops.set(project.id, top);
+
+      const previousTop = previousTopsRef.current.get(project.id);
+      const delta = previousTop === undefined ? 0 : previousTop - top;
+      if (delta === 0 || project.id === draggedProjectId) return;
+
+      node.animate(
+        [
+          { transform: `translateY(${delta}px)` },
+          { transform: "translateY(0)" },
+        ],
+        {
+          duration: 180,
+          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+        },
+      );
+    });
+
+    previousTopsRef.current = nextTops;
+  }, [projects, draggedProjectId]);
+
+  const draggedProject =
+    draggedProjectId ? projects.find((project) => project.id === draggedProjectId) ?? null : null;
 
   return (
     <div
@@ -249,9 +473,34 @@ export function ProjectRail({
           project={project}
           isActive={project.id === activeProjectId}
           status={getProjectStatus(allTasks, project.id)}
+          isDragging={draggedProjectId === project.id}
+          isDragTarget={dragTargetProjectId === project.id && draggedProjectId !== project.id}
           onSwitch={(p) => {
+            if (dragMovedRef.current || suppressClickRef.current) return;
             onSwitch(p);
             setDrawerOpen(false);
+          }}
+          onPointerDown={(projectId, event) => {
+            draggedProjectIdRef.current = projectId;
+            lastHoverProjectIdRef.current = projectId;
+            pointerStartRef.current = { x: event.x, y: event.y };
+            activePointerIdRef.current = event.pointerId;
+            activePointerNodeRef.current = event.node;
+            event.node.setPointerCapture(event.pointerId);
+            setDragPreview({
+              x: event.x - event.offsetX,
+              y: event.y - event.offsetY,
+              width: event.width,
+              height: event.height,
+              offsetX: event.offsetX,
+              offsetY: event.offsetY,
+            });
+            setDraggedProjectId(projectId);
+            dragMovedRef.current = false;
+            reorderChangedRef.current = false;
+          }}
+          onMount={(projectId, node) => {
+            itemRefs.current[projectId] = node;
           }}
         />
       ))}
@@ -312,6 +561,17 @@ export function ProjectRail({
       >
         <Plus size={14} strokeWidth={2.5} />
       </button>
+
+      {draggedProject && dragPreview && (
+        <DragPreview
+          project={draggedProject}
+          status={getProjectStatus(allTasks, draggedProject.id)}
+          x={dragPreview.x}
+          y={dragPreview.y}
+          width={dragPreview.width}
+          height={dragPreview.height}
+        />
+      )}
 
       {drawerOpen && (
         <ProjectDrawer


### PR DESCRIPTION
 ## Summary

  This PR adds drag-and-drop reordering for the left project rail.

  Users can now drag project icons in the far-left sidebar to reorder them directly. The new order is preserved by
  saving the reordered `projects` array on drag end, without changing the existing storage schema.

  ## Changes

  - add pointer-based drag-and-drop support to `ProjectRail`
  - add a floating drag preview that follows the pointer
  - animate rail item position changes during reorder
  - suppress accidental project switching after drag
  - persist the reordered project list when drag completes
  - render rail projects in stored array order instead of sorting by project id

  ## Notes

  - no storage fields were added
  - project order is persisted via the existing `projects` array order in `~/.nezha/projects.json`

  ## Verification

  - `pnpm lint`
  - `pnpm build`
  - manually verified:
    - project icons can be dragged to reorder
    - reordered project positions update visually
    - drag preview follows the pointer correctly
    - order persists after drag completes
    - dragging out of the window does not leave the rail in a stuck drag state