### PR TITLE
feat: 完善会话恢复与全局代理配置，新增回填开关

### DIFF
--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -28,6 +28,10 @@ pub struct AppSettings {
     pub claude_path: String,
     #[serde(default)]
     pub codex_path: String,
+    #[serde(default)]
+    pub proxy_url: String,
+    #[serde(default)]
+    pub enable_session_backfill: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -35,6 +39,8 @@ pub struct AgentLaunchSpec {
     pub program: String,
     pub extra_env: Vec<(String, String)>,
 }
+
+const SUPPORTED_PROXY_SCHEMES: &[&str] = &["http", "https", "socks5", "socks5h"];
 
 fn get_agent_configured_path(settings: &AppSettings, agent: &str) -> String {
     match agent {
@@ -270,14 +276,81 @@ fn resolve_agent_launch_spec_from_path(agent: &str, path: &str) -> AgentLaunchSp
 }
 
 fn get_agent_launch_spec_from_settings(settings: &AppSettings, agent: &str) -> AgentLaunchSpec {
-    resolve_agent_launch_spec_from_path(agent, &get_agent_configured_path(settings, agent))
+    let mut launch =
+        resolve_agent_launch_spec_from_path(agent, &get_agent_configured_path(settings, agent));
+    launch
+        .extra_env
+        .extend(proxy_env_vars_from_settings(settings));
+    launch
+}
+
+fn proxy_env_vars_from_settings(settings: &AppSettings) -> Vec<(String, String)> {
+    let proxy = settings.proxy_url.trim();
+    if proxy.is_empty() {
+        return Vec::new();
+    }
+
+    vec![("ALL_PROXY".to_string(), proxy.to_string())]
+}
+
+pub fn apply_proxy_env(cmd: &mut Command) {
+    for (key, value) in proxy_env_vars_from_settings(&load_settings_internal()) {
+        cmd.env(key, value);
+    }
+}
+
+pub fn apply_proxy_env_tokio(cmd: &mut tokio::process::Command) {
+    for (key, value) in proxy_env_vars_from_settings(&load_settings_internal()) {
+        cmd.env(key, value);
+    }
+}
+
+pub fn apply_proxy_to_reqwest_builder(
+    builder: reqwest::ClientBuilder,
+) -> Result<reqwest::ClientBuilder, String> {
+    let settings = load_settings_internal();
+    let proxy = settings.proxy_url.trim();
+    if proxy.is_empty() {
+        return Ok(builder);
+    }
+
+    let reqwest_proxy =
+        reqwest::Proxy::all(proxy).map_err(|e| format!("Invalid proxy configuration: {e}"))?;
+    Ok(builder.proxy(reqwest_proxy))
 }
 
 fn normalize_settings(settings: AppSettings) -> AppSettings {
     AppSettings {
         claude_path: resolve_agent_launch_spec_from_path("claude", &settings.claude_path).program,
         codex_path: resolve_agent_launch_spec_from_path("codex", &settings.codex_path).program,
+        proxy_url: settings.proxy_url.trim().to_string(),
+        enable_session_backfill: settings.enable_session_backfill,
     }
+}
+
+fn validate_proxy_url(proxy_url: &str) -> Result<(), String> {
+    if proxy_url.is_empty() {
+        return Ok(());
+    }
+
+    let parsed = reqwest::Url::parse(proxy_url)
+        .map_err(|_| "Proxy URL must be a valid absolute URL.".to_string())?;
+    if !SUPPORTED_PROXY_SCHEMES.contains(&parsed.scheme()) {
+        return Err(format!(
+            "Proxy URL scheme must be one of: {}.",
+            SUPPORTED_PROXY_SCHEMES.join(", ")
+        ));
+    }
+
+    if parsed.host_str().is_none() {
+        return Err("Proxy URL must include a hostname.".to_string());
+    }
+
+    Ok(())
+}
+
+fn validate_settings(settings: &AppSettings) -> Result<(), String> {
+    validate_proxy_url(&settings.proxy_url)
 }
 
 pub fn load_settings_internal() -> AppSettings {
@@ -290,6 +363,8 @@ pub fn load_settings_internal() -> AppSettings {
         let settings = normalize_settings(AppSettings {
             claude_path: detect_path("claude"),
             codex_path: detect_path("codex"),
+            proxy_url: String::new(),
+            enable_session_backfill: false,
         });
         if let Ok(dir) = nezha_dir() {
             let _ = fs::create_dir_all(&dir);
@@ -329,6 +404,7 @@ pub fn save_app_settings(settings: AppSettings) -> Result<(), String> {
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     let path = settings_path()?;
     let normalized = normalize_settings(settings);
+    validate_settings(&normalized)?;
     let raw = serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?;
     atomic_write(&path, &raw)?;
     clear_cached_versions();
@@ -337,9 +413,12 @@ pub fn save_app_settings(settings: AppSettings) -> Result<(), String> {
 
 #[tauri::command]
 pub fn detect_agent_paths() -> Result<AppSettings, String> {
+    let current = load_settings_internal();
     Ok(normalize_settings(AppSettings {
         claude_path: detect_path("claude"),
         codex_path: detect_path("codex"),
+        proxy_url: current.proxy_url,
+        enable_session_backfill: current.enable_session_backfill,
     }))
 }
 
@@ -429,7 +508,9 @@ pub fn detect_agent_versions() -> Result<AgentVersions, String> {
 
 #[tauri::command]
 pub fn detect_agent_versions_for_settings(settings: AppSettings) -> Result<AgentVersions, String> {
-    Ok(detect_versions_for_settings(&settings))
+    let normalized = normalize_settings(settings);
+    validate_settings(&normalized)?;
+    Ok(detect_versions_for_settings(&normalized))
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -11,6 +11,8 @@ const DEFAULT_CONFIG: &str = r#"# Nezha project configuration
 default = "claude"
 # Default permission mode for new tasks: "ask", "auto_edit", or "full_access"
 default_permission_mode = "ask"
+# Whether new tasks start with plan mode enabled by default
+default_plan_mode = false
 # Text automatically prepended (followed by a newline) to every task prompt
 prompt_prefix = ""
 
@@ -29,6 +31,8 @@ pub struct AgentConfig {
     pub default: String,
     #[serde(default = "default_permission_mode")]
     pub default_permission_mode: String,
+    #[serde(default)]
+    pub default_plan_mode: bool,
     #[serde(default)]
     pub prompt_prefix: String,
     #[serde(default)]
@@ -58,6 +62,7 @@ impl Default for ProjectConfig {
             agent: AgentConfig {
                 default: "claude".to_string(),
                 default_permission_mode: "ask".to_string(),
+                default_plan_mode: false,
                 prompt_prefix: String::new(),
                 claude_version: String::new(),
                 codex_version: String::new(),

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -164,6 +164,7 @@ pub async fn read_dir_entries(path: String, project_path: String) -> Result<Vec<
                 use std::io::Write;
                 let mut cmd = std::process::Command::new("git");
                 crate::subprocess::configure_background_command(&mut cmd);
+                crate::app_settings::apply_proxy_env(&mut cmd);
                 cmd.args(["check-ignore", "--stdin"])
                     .current_dir(&project_path)
                     .stdin(std::process::Stdio::piped())
@@ -272,6 +273,7 @@ pub async fn list_project_files(project_path: String) -> Result<Vec<String>, Str
     tauri::async_runtime::spawn_blocking(move || {
         let mut cmd = std::process::Command::new("git");
         crate::subprocess::configure_background_command(&mut cmd);
+        crate::app_settings::apply_proxy_env(&mut cmd);
         let output = cmd
             .args([
                 "-c",

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -38,6 +38,7 @@ fn run_git<S: AsRef<std::ffi::OsStr>>(
 
     let mut cmd = std::process::Command::new("git");
     crate::subprocess::configure_background_command(&mut cmd);
+    crate::app_settings::apply_proxy_env(&mut cmd);
     cmd.args(args)
         .current_dir(project_path)
         .output()
@@ -66,6 +67,7 @@ async fn run_git_with_timeout(
 
     let mut cmd = tokio::process::Command::new("git");
     crate::subprocess::configure_background_tokio_command(&mut cmd);
+    crate::app_settings::apply_proxy_env_tokio(&mut cmd);
     let mut child = cmd
         .args(&args)
         .current_dir(&project_path)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,8 @@ pub fn run() {
             analytics::read_session_metrics,
             analytics::get_weekly_analytics,
             session::read_session_messages,
+            session::resolve_session_path,
+            session::recover_codex_sessions_for_tasks,
             config::init_project_config,
             config::read_project_config,
             config::write_project_config,

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -232,9 +232,10 @@ fn is_valid(notif: &RemoteNotification, app_version: &str) -> bool {
 // ── HTTP fetch (async, with strict guards) ───────────────────────────────────
 
 async fn fetch_remote() -> Result<Vec<RemoteNotification>, String> {
-    let client = reqwest::Client::builder()
+    let builder = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .redirect(reqwest::redirect::Policy::none()) // no redirects to prevent domain bypass
+        .redirect(reqwest::redirect::Policy::none()); // no redirects to prevent domain bypass
+    let client = crate::app_settings::apply_proxy_to_reqwest_builder(builder)?
         .build()
         .map_err(|e| format!("HTTP client error: {e}"))?;
 

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::TaskManager;
@@ -124,6 +126,17 @@ fn codex_sessions_roots(project_path: &str) -> Vec<PathBuf> {
         }
     }
     roots
+}
+
+fn emit_task_session(app: &AppHandle, task_id: &str, session_id: &str, session_path: &str) {
+    let _ = app.emit(
+        "task-session",
+        serde_json::json!({
+            "task_id": task_id,
+            "session_id": session_id,
+            "session_path": session_path
+        }),
+    );
 }
 
 fn collect_session_files_from_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
@@ -983,8 +996,8 @@ fn slug_matches_session_file(path: &Path, slug: &str) -> bool {
 
 fn find_codex_session_file(session_id: &str, project_path: &str) -> Option<PathBuf> {
     let suffix = format!("-{}.jsonl", session_id);
-    let files = collect_session_files_from_roots(&codex_sessions_roots(project_path));
-    files
+    let project_root = PathBuf::from(project_path).join(".codex").join("sessions");
+    let project_match = collect_session_files_from_roots(&[project_root])
         .into_iter()
         .filter(|p| {
             p.file_name()
@@ -992,7 +1005,178 @@ fn find_codex_session_file(session_id: &str, project_path: &str) -> Option<PathB
                 .map(|n| n.ends_with(&suffix))
                 .unwrap_or(false)
         })
+        .max_by_key(|p| session_modified_at(p));
+    if project_match.is_some() {
+        return project_match;
+    }
+
+    codex_sessions_roots(project_path)
+        .into_iter()
+        .skip(1)
+        .flat_map(|root| collect_session_files_from_roots(&[root]))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.ends_with(&suffix))
+                .unwrap_or(false)
+        })
         .max_by_key(|p| session_modified_at(p))
+}
+
+#[derive(Clone)]
+struct CodexSessionMeta {
+    session_id: String,
+    session_path: String,
+    cwd: String,
+    started_at_ms: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexTaskRecoveryHint {
+    task_id: String,
+    created_at: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexTaskRecoveredSession {
+    task_id: String,
+    session_id: String,
+    session_path: String,
+    started_at: i64,
+    delta_ms: i64,
+}
+
+fn normalize_path_for_compare(path: &str) -> String {
+    path.trim_end_matches(|c| c == '/' || c == '\\').to_string()
+}
+
+fn read_codex_session_meta(path: &Path) -> Option<CodexSessionMeta> {
+    use std::io::BufRead;
+    let file = File::open(path).ok()?;
+    let mut lines = BufReader::new(file).lines();
+    for _ in 0..64 {
+        let line = lines.next()?.ok()?;
+        let value = serde_json::from_str::<serde_json::Value>(&line).ok()?;
+        if value.get("type").and_then(|v| v.as_str()) != Some("session_meta") {
+            continue;
+        }
+        let payload = value.get("payload")?.as_object()?;
+        let session_id = payload.get("id").and_then(|v| v.as_str())?.to_string();
+        if !is_uuid_like(&session_id) {
+            return None;
+        }
+        let cwd = payload.get("cwd").and_then(|v| v.as_str())?.to_string();
+        let ts = value.get("timestamp").and_then(|v| v.as_str())?;
+        let started_at_ms = DateTime::parse_from_rfc3339(ts).ok()?.timestamp_millis();
+        return Some(CodexSessionMeta {
+            session_id,
+            session_path: path.to_string_lossy().into_owned(),
+            cwd,
+            started_at_ms,
+        });
+    }
+    None
+}
+
+fn recover_codex_sessions_for_tasks_sync(
+    project_path: String,
+    tasks: Vec<CodexTaskRecoveryHint>,
+) -> Vec<CodexTaskRecoveredSession> {
+    if tasks.is_empty() {
+        return Vec::new();
+    }
+
+    let mut task_hints = tasks;
+    task_hints.sort_by_key(|task| task.created_at);
+
+    let roots = codex_sessions_roots(&project_path);
+    let project_path_normalized = normalize_path_for_compare(&project_path);
+    let mut session_candidates: Vec<CodexSessionMeta> = collect_session_files_from_roots(&roots)
+        .into_iter()
+        .filter_map(|path| read_codex_session_meta(&path))
+        .filter(|meta| normalize_path_for_compare(&meta.cwd) == project_path_normalized)
+        .collect();
+    session_candidates.sort_by_key(|meta| meta.started_at_ms);
+
+    // 回填只用于兜底，避免错绑优先于“尽可能多恢复”。
+    // 允许 session 比任务创建晚最多 2 小时，或早最多 2 分钟（时钟抖动）。
+    const MAX_SESSION_MATCH_DELTA_MS: i64 = 1000 * 60 * 60 * 2;
+    const MAX_EARLY_START_MS: i64 = 1000 * 60 * 2;
+    let mut recovered = Vec::new();
+
+    for task in task_hints {
+        let best = session_candidates
+            .iter()
+            .enumerate()
+            .map(|(index, candidate)| {
+                let drift = candidate.started_at_ms - task.created_at;
+                (index, drift)
+            })
+            .filter(|(_, drift)| *drift >= -MAX_EARLY_START_MS)
+            .filter(|(_, drift)| drift.abs() <= MAX_SESSION_MATCH_DELTA_MS)
+            .min_by_key(|(_, delta)| *delta);
+
+        let Some((index, delta)) = best else {
+            continue;
+        };
+
+        let matched = session_candidates.remove(index);
+        recovered.push(CodexTaskRecoveredSession {
+            task_id: task.task_id,
+            session_id: matched.session_id,
+            session_path: matched.session_path,
+            started_at: matched.started_at_ms,
+            delta_ms: delta.abs(),
+        });
+    }
+
+    recovered
+}
+
+fn find_recent_codex_session_for_project(
+    project_path: &str,
+    min_started_at_ms: i64,
+) -> Option<CodexSessionMeta> {
+    let project_path_normalized = normalize_path_for_compare(project_path);
+    collect_session_files_from_roots(&codex_sessions_roots(project_path))
+        .into_iter()
+        .filter_map(|path| read_codex_session_meta(&path))
+        .filter(|meta| normalize_path_for_compare(&meta.cwd) == project_path_normalized)
+        .filter(|meta| meta.started_at_ms >= min_started_at_ms)
+        .max_by_key(|meta| meta.started_at_ms)
+}
+
+#[tauri::command]
+pub async fn recover_codex_sessions_for_tasks(
+    project_path: String,
+    tasks: Vec<CodexTaskRecoveryHint>,
+) -> Result<Vec<CodexTaskRecoveredSession>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        recover_codex_sessions_for_tasks_sync(project_path, tasks)
+    })
+    .await
+    .map_err(|e| format!("recover_codex_sessions_for_tasks failed: {e}"))
+}
+
+#[tauri::command]
+pub fn resolve_session_path(
+    project_path: String,
+    agent: String,
+    session_id: String,
+) -> Result<Option<String>, String> {
+    if session_id.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let path = if agent == "codex" {
+        find_codex_session_file(&session_id, &project_path)
+    } else {
+        find_claude_session_file(&session_id, &project_path)
+    };
+
+    Ok(path.map(|p| p.to_string_lossy().into_owned()))
 }
 
 // ── /status-based session discovery ──────────────────────────────────────────
@@ -1090,14 +1274,7 @@ pub(crate) fn register_and_watch_session(
         );
     }
 
-    let _ = app.emit(
-        "task-session",
-        serde_json::json!({
-            "task_id": task_id,
-            "session_id": session_id,
-            "session_path": path_string
-        }),
-    );
+    emit_task_session(app, task_id, session_id, &path_string);
 
     let app_clone = app.clone();
     let tid = task_id.to_string();
@@ -1124,10 +1301,10 @@ fn should_send_status_command(
 
     if is_codex {
         first_output_elapsed
-            .map(|elapsed| elapsed >= Duration::from_secs(1))
+            .map(|elapsed| elapsed >= Duration::from_millis(500))
             .unwrap_or(false)
-            // 兜底：若 Codex 长时间无输出，也不要无限等待
-            || start_elapsed >= Duration::from_secs(8)
+            // 兜底：无输出也尽早触发一次 /status，避免快速取消时拿不到 session id
+            || start_elapsed >= Duration::from_secs(2)
     } else {
         start_elapsed >= Duration::from_millis(1500)
     }
@@ -1186,6 +1363,7 @@ pub(crate) fn spawn_status_session_watcher(
             let pp2 = project_path.clone();
             let sid2 = sid.clone();
             thread::spawn(move || {
+                emit_task_session(&app2, &tid2, &sid2, "");
                 // 等待 Claude 创建 session 文件，最长 10 秒
                 register_and_watch_session(&app2, &tid2, &sid2, &pp2, false);
 
@@ -1225,10 +1403,12 @@ fn run_status_session_watcher(
     rx: mpsc::Receiver<String>,
 ) {
         let start_time = Instant::now();
+        let start_wall_ms = chrono::Utc::now().timestamp_millis();
         let mut status_sent = false;
         let mut status_sent_at: Option<Instant> = None;
         let mut status_send_count: u32 = 0;
         let mut first_output_at = None;
+        let mut discovered_session = false;
         let mut accumulated = String::new();
         // 发送 /status 后的独立缓冲，避免大量输出将 /status 响应挤出裁剪窗口
         let mut status_response_buf = String::new();
@@ -1294,7 +1474,9 @@ fn run_status_session_watcher(
                     };
 
                     if let Some(sid) = session_id {
+                        emit_task_session(&app, &task_id, &sid, "");
                         register_and_watch_session(&app, &task_id, &sid, &project_path, is_codex);
+                        discovered_session = true;
                         // Claude Code 的 /status 以全屏面板形式展示，需发送 ESC 关闭；
                         // Codex 无此面板，无需处理
                         if !is_codex {
@@ -1310,6 +1492,16 @@ fn run_status_session_watcher(
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        if is_codex && !discovered_session {
+            if let Some(meta) = find_recent_codex_session_for_project(
+                &project_path,
+                start_wall_ms - 1000 * 60 * 2,
+            ) {
+                emit_task_session(&app, &task_id, &meta.session_id, "");
+                register_and_watch_session(&app, &task_id, &meta.session_id, &project_path, true);
             }
         }
 }

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -18,9 +18,9 @@ const CODEX_ATTEMPT_TIMEOUT_SECS: u64 = 10;
 const CLAUDE_429_BACKOFF_SECS: u64 = 300; // 5 分钟
 
 static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(CLAUDE_TIMEOUT_SECS))
-        .build()
+    let builder = reqwest::Client::builder().timeout(Duration::from_secs(CLAUDE_TIMEOUT_SECS));
+    crate::app_settings::apply_proxy_to_reqwest_builder(builder)
+        .and_then(|builder| builder.build().map_err(|e| e.to_string()))
         .unwrap_or_else(|_| reqwest::Client::new())
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,84 @@ function createDefaultProjectViewState(): ProjectViewState {
   return { selectedTaskId: null, isNewTask: true };
 }
 
+function reconcileRecoveredTasks(loadedTasks: Task[]): Task[] {
+  return loadedTasks.map((task) => {
+    if (!isActiveTaskStatus(task.status)) {
+      return task;
+    }
+
+    return {
+      ...task,
+      status: "cancelled",
+      attentionRequestedAt: undefined,
+    };
+  });
+}
+
+function applyRecoveredSessionPaths(tasks: Task[], resolvedPaths: Record<string, string>): Task[] {
+  let changed = false;
+  const next = tasks.map((task) => {
+    const resolvedPath = resolvedPaths[task.id];
+    if (!resolvedPath) {
+      return task;
+    }
+    if (task.agent === "codex") {
+      if (task.codexSessionPath === resolvedPath) {
+        return task;
+      }
+      changed = true;
+      return { ...task, codexSessionPath: resolvedPath };
+    }
+    if (task.claudeSessionPath === resolvedPath) {
+      return task;
+    }
+    changed = true;
+    return { ...task, claudeSessionPath: resolvedPath };
+  });
+  return changed ? next : tasks;
+}
+
+interface RecoveredCodexSession {
+  taskId: string;
+  sessionId: string;
+  sessionPath: string;
+  startedAt: number;
+  deltaMs: number;
+}
+
+interface AppSettingsLite {
+  enable_session_backfill?: boolean;
+}
+
+function applyRecoveredCodexSessions(
+  tasks: Task[],
+  recovered: Record<string, { sessionId: string; sessionPath: string }>,
+): Task[] {
+  let changed = false;
+  const next = tasks.map((task) => {
+    if (task.agent !== "codex") {
+      return task;
+    }
+    const recoveredSession = recovered[task.id];
+    if (!recoveredSession) {
+      return task;
+    }
+    if (
+      task.codexSessionId === recoveredSession.sessionId &&
+      task.codexSessionPath === recoveredSession.sessionPath
+    ) {
+      return task;
+    }
+    changed = true;
+    return {
+      ...task,
+      codexSessionId: recoveredSession.sessionId,
+      codexSessionPath: recoveredSession.sessionPath,
+    };
+  });
+  return changed ? next : tasks;
+}
+
 function getSystemPrefersDark() {
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
@@ -129,6 +207,11 @@ function App() {
 
   useEffect(() => {
     async function init() {
+      const appSettings = await invoke<AppSettingsLite>("load_app_settings").catch(
+        () => ({ enable_session_backfill: false }),
+      );
+      const enableSessionBackfill = appSettings.enable_session_backfill === true;
+
       // Load projects from ~/.nezha/projects.json
       const loadedProjects = await invoke<Project[]>("load_projects");
       setProjects(loadedProjects);
@@ -137,11 +220,124 @@ function App() {
       const chunks = await Promise.all(
         loadedProjects.map((p) => invoke<Task[]>("load_project_tasks", { projectId: p.id })),
       );
-      setTasks(chunks.flat());
+      const loadedTasks = chunks.flat();
+      const reconciledTasks = reconcileRecoveredTasks(loadedTasks);
+      let hydratedTasks = reconciledTasks;
+
+      const dirtyProjectIds = new Set<string>();
+      for (let i = 0; i < loadedTasks.length; i++) {
+        if (loadedTasks[i].status !== reconciledTasks[i].status) {
+          dirtyProjectIds.add(loadedTasks[i].projectId);
+        }
+      }
+
+      const sessionLookupTasks = reconciledTasks.filter((task) => {
+        const sessionId = task.agent === "codex" ? task.codexSessionId : task.claudeSessionId;
+        const sessionPath = task.agent === "codex" ? task.codexSessionPath : task.claudeSessionPath;
+        return Boolean(sessionId && !sessionPath);
+      });
+      if (sessionLookupTasks.length > 0) {
+        const resolvedEntries = await Promise.all(
+          sessionLookupTasks.map(async (task) => {
+            const sessionId =
+              task.agent === "codex" ? task.codexSessionId ?? "" : task.claudeSessionId ?? "";
+            const projectPath =
+              loadedProjects.find((project) => project.id === task.projectId)?.path ?? "";
+            const sessionPath = await invoke<string | null>("resolve_session_path", {
+              projectPath,
+              agent: task.agent,
+              sessionId,
+            }).catch(() => null);
+            return [task.id, sessionPath ?? ""] as const;
+          }),
+        );
+        const resolvedPaths = Object.fromEntries(
+          resolvedEntries.filter(([, sessionPath]) => Boolean(sessionPath)),
+        );
+        hydratedTasks = applyRecoveredSessionPaths(reconciledTasks, resolvedPaths);
+        for (let i = 0; i < reconciledTasks.length; i++) {
+          const prevPath =
+            reconciledTasks[i].agent === "codex"
+              ? reconciledTasks[i].codexSessionPath
+              : reconciledTasks[i].claudeSessionPath;
+          const nextPath =
+            hydratedTasks[i].agent === "codex"
+              ? hydratedTasks[i].codexSessionPath
+              : hydratedTasks[i].claudeSessionPath;
+          if (prevPath !== nextPath) {
+            dirtyProjectIds.add(reconciledTasks[i].projectId);
+          }
+        }
+      }
+
+      if (enableSessionBackfill) {
+        const codexSessionBackfillByProject = new Map<string, Task[]>();
+        for (const task of hydratedTasks) {
+          if (
+            task.agent !== "codex" ||
+            task.status === "todo" ||
+            isActiveTaskStatus(task.status) ||
+            task.codexSessionId ||
+            task.codexSessionPath
+          ) {
+            continue;
+          }
+          const group = codexSessionBackfillByProject.get(task.projectId) ?? [];
+          group.push(task);
+          codexSessionBackfillByProject.set(task.projectId, group);
+        }
+        if (codexSessionBackfillByProject.size > 0) {
+          const recoveredSessions: Record<string, { sessionId: string; sessionPath: string }> = {};
+          const recoveredGroups = await Promise.all(
+            Array.from(codexSessionBackfillByProject.entries()).map(
+              async ([projectId, projectTasks]) => {
+                const projectPath =
+                  loadedProjects.find((project) => project.id === projectId)?.path ?? "";
+                const recovered = await invoke<RecoveredCodexSession[]>(
+                  "recover_codex_sessions_for_tasks",
+                  {
+                    projectPath,
+                    tasks: projectTasks.map((task) => ({
+                      taskId: task.id,
+                      createdAt: task.createdAt,
+                    })),
+                  },
+                ).catch(() => []);
+                return recovered;
+              },
+            ),
+          );
+          for (const recovered of recoveredGroups) {
+            for (const item of recovered) {
+              recoveredSessions[item.taskId] = {
+                sessionId: item.sessionId,
+                sessionPath: item.sessionPath,
+              };
+            }
+          }
+
+          const previousTasks = hydratedTasks;
+          hydratedTasks = applyRecoveredCodexSessions(hydratedTasks, recoveredSessions);
+          for (let i = 0; i < previousTasks.length; i++) {
+            if (
+              previousTasks[i].codexSessionId !== hydratedTasks[i].codexSessionId ||
+              previousTasks[i].codexSessionPath !== hydratedTasks[i].codexSessionPath
+            ) {
+              dirtyProjectIds.add(previousTasks[i].projectId);
+            }
+          }
+        }
+      }
+
+      setTasks(hydratedTasks);
+
+      for (const projectId of dirtyProjectIds) {
+        persistProjectTasks(projectId, hydratedTasks, showToast);
+      }
     }
 
     init().catch(console.error);
-  }, []);
+  }, [showToast]);
 
   // Tauri event listeners (agent-output is handled inside useTerminalManager)
   useEffect(() => {
@@ -483,15 +679,17 @@ function App() {
       const next = prev.map((task) => {
         if (task.id !== taskId) return task;
         if (task.agent === "claude") {
-          if (task.claudeSessionId === sessionId && task.claudeSessionPath === sessionPath)
+          const nextPath = sessionPath || task.claudeSessionPath || "";
+          if (task.claudeSessionId === sessionId && (task.claudeSessionPath || "") === nextPath)
             return task;
           changed = true;
-          return { ...task, claudeSessionId: sessionId, claudeSessionPath: sessionPath };
+          return { ...task, claudeSessionId: sessionId, claudeSessionPath: nextPath || undefined };
         } else {
-          if (task.codexSessionId === sessionId && task.codexSessionPath === sessionPath)
+          const nextPath = sessionPath || task.codexSessionPath || "";
+          if (task.codexSessionId === sessionId && (task.codexSessionPath || "") === nextPath)
             return task;
           changed = true;
-          return { ...task, codexSessionId: sessionId, codexSessionPath: sessionPath };
+          return { ...task, codexSessionId: sessionId, codexSessionPath: nextPath || undefined };
         }
       });
 

--- a/src/components/AppSettingsDialog.tsx
+++ b/src/components/AppSettingsDialog.tsx
@@ -34,6 +34,8 @@ type NavKey = "general" | "theme" | "about" | "claude" | "codex";
 interface AppSettings {
   claude_path: string;
   codex_path: string;
+  proxy_url: string;
+  enable_session_backfill: boolean;
 }
 
 interface AgentVersions {
@@ -42,6 +44,7 @@ interface AgentVersions {
 }
 
 type AgentKey = "claude" | "codex";
+const SUPPORTED_PROXY_PROTOCOLS = ["http:", "https:", "socks5:", "socks5h:"];
 
 const GITHUB_REPO_URL = "https://github.com/hanshuaikang/nezha";
 
@@ -71,6 +74,26 @@ function getAgentExecutablePlaceholder(agent: AgentKey): string {
   return agent === "claude"
     ? "claude or /usr/local/bin/claude"
     : "codex or /usr/local/bin/codex";
+}
+
+function getProxyUrlError(proxyUrl: string): string | null {
+  const trimmed = proxyUrl.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!SUPPORTED_PROXY_PROTOCOLS.includes(parsed.protocol)) {
+      return "Use http://, https://, socks5://, or socks5h://";
+    }
+    if (!parsed.hostname) {
+      return "Proxy URL must include a hostname";
+    }
+    return null;
+  } catch {
+    return "Proxy URL must be a valid absolute URL";
+  }
 }
 
 const NAV_ITEMS: Array<{
@@ -535,8 +558,18 @@ function ThemePanel({ themeMode, systemPrefersDark, onThemeModeChange }: ThemePa
 // ── General Panel ─────────────────────────────────────────────────────────────
 
 function GeneralPanel() {
-  const [settings, setSettings] = useState<AppSettings>({ claude_path: "", codex_path: "" });
-  const [original, setOriginal] = useState<AppSettings>({ claude_path: "", codex_path: "" });
+  const [settings, setSettings] = useState<AppSettings>({
+    claude_path: "",
+    codex_path: "",
+    proxy_url: "",
+    enable_session_backfill: false,
+  });
+  const [original, setOriginal] = useState<AppSettings>({
+    claude_path: "",
+    codex_path: "",
+    proxy_url: "",
+    enable_session_backfill: false,
+  });
   const [versions, setVersions] = useState<AgentVersions>({
     claude_version: "",
     codex_version: "",
@@ -546,7 +579,10 @@ function GeneralPanel() {
   const [refreshingVersions, setRefreshingVersions] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+
+  const proxyError = getProxyUrlError(settings.proxy_url);
+  const error = requestError ?? proxyError;
 
   async function loadVersions(nextSettings: AppSettings) {
     setRefreshingVersions(true);
@@ -555,8 +591,9 @@ function GeneralPanel() {
         settings: nextSettings,
       });
       setVersions(detected);
+      setRequestError(null);
     } catch (e) {
-      setError(String(e));
+      setRequestError(String(e));
     } finally {
       setRefreshingVersions(false);
     }
@@ -569,27 +606,35 @@ function GeneralPanel() {
         setOriginal(loadedSettings);
         await loadVersions(loadedSettings);
       })
-      .catch((e) => setError(String(e)))
+      .catch((e) => setRequestError(String(e)))
       .finally(() => setLoading(false));
   }, []);
 
   async function handleDetect() {
     setDetectingPaths(true);
-    setError(null);
+    setRequestError(null);
     try {
       const detected = await invoke<AppSettings>("detect_agent_paths");
-      setSettings(detected);
-      await loadVersions(detected);
+      const merged = {
+        ...detected,
+        proxy_url: settings.proxy_url,
+        enable_session_backfill: settings.enable_session_backfill,
+      };
+      setSettings(merged);
+      await loadVersions(merged);
     } catch (e) {
-      setError(String(e));
+      setRequestError(String(e));
     } finally {
       setDetectingPaths(false);
     }
   }
 
   async function handleSave() {
+    if (proxyError) {
+      return;
+    }
     setSaving(true);
-    setError(null);
+    setRequestError(null);
     setSaved(false);
     try {
       await invoke("save_app_settings", { settings });
@@ -598,14 +643,17 @@ function GeneralPanel() {
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
-      setError(String(e));
+      setRequestError(String(e));
     } finally {
       setSaving(false);
     }
   }
 
   const isDirty =
-    settings.claude_path !== original.claude_path || settings.codex_path !== original.codex_path;
+    settings.claude_path !== original.claude_path ||
+    settings.codex_path !== original.codex_path ||
+    settings.proxy_url !== original.proxy_url ||
+    settings.enable_session_backfill !== original.enable_session_backfill;
 
   const inputStyle: React.CSSProperties = {
     width: "100%",
@@ -739,6 +787,72 @@ function GeneralPanel() {
               <span style={hintStyle}>Leave empty to use codex from the system PATH.</span>
             </div>
 
+            <div style={fieldStyle}>
+              <label style={labelStyle}>Agent Proxy URL</label>
+              <input
+                style={inputStyle}
+                value={settings.proxy_url}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setSettings((prev) => ({ ...prev, proxy_url: value }));
+                  if (requestError) {
+                    setRequestError(null);
+                  }
+                }}
+                placeholder="http://127.0.0.1:7890 or socks5://127.0.0.1:7890"
+                spellCheck={false}
+              />
+              <span
+                style={{
+                  ...hintStyle,
+                  color: proxyError ? "var(--danger)" : hintStyle.color,
+                }}
+              >
+                {proxyError ?? (
+                  <>
+                    When set, Nezha exports this value to Claude Code and Codex as ALL_PROXY
+                    during internal launches.
+                  </>
+                )}
+              </span>
+              {!proxyError && (
+                <span style={hintStyle}>
+                  Supported schemes: http, https, socks5, socks5h.
+                </span>
+              )}
+            </div>
+
+            <div style={fieldStyle}>
+              <label style={labelStyle}>Session Backfill</label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  fontSize: 12.5,
+                  color: "var(--text-secondary)",
+                  cursor: "pointer",
+                  userSelect: "none",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={settings.enable_session_backfill}
+                  onChange={(e) =>
+                    setSettings((prev) => ({
+                      ...prev,
+                      enable_session_backfill: e.target.checked,
+                    }))
+                  }
+                />
+                Enable startup session backfill recovery
+              </label>
+              <span style={hintStyle}>
+                Disabled by default. Turn on only if you want Nezha to backfill missing session IDs
+                from local Codex session files at app startup.
+              </span>
+            </div>
+
             <div style={{ ...fieldStyle, marginBottom: 0 }}>
               <label style={labelStyle}>Installed Versions</label>
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
@@ -791,9 +905,9 @@ function GeneralPanel() {
           </span>
         )}
         <button
-          style={{ ...s.modalSaveBtn, opacity: saving || !isDirty ? 0.5 : 1 }}
+          style={{ ...s.modalSaveBtn, opacity: saving || !isDirty || !!proxyError ? 0.5 : 1 }}
           onClick={handleSave}
-          disabled={saving || !isDirty}
+          disabled={saving || !isDirty || !!proxyError}
         >
           {saving ? "Saving..." : "Save"}
         </button>

--- a/src/components/NewTaskView.tsx
+++ b/src/components/NewTaskView.tsx
@@ -23,6 +23,20 @@ interface PastedImage {
 
 type CrossProjectFileMap = Map<string, FileEntry[]>;
 
+interface ProjectConfig {
+  agent: {
+    default: string;
+    default_permission_mode?: string;
+    default_plan_mode?: boolean;
+    prompt_prefix?: string;
+    claude_version?: string;
+    codex_version?: string;
+  };
+  git: {
+    commit_prompt?: string;
+  };
+}
+
 function parseFileEntry(f: string): FileEntry {
   const parts = f.split("/");
   const name = parts[parts.length - 1];
@@ -63,6 +77,8 @@ export function NewTaskView({
   const [filesLoading, setFilesLoading] = useState(false);
   const [crossProjectFiles, setCrossProjectFiles] = useState<CrossProjectFileMap>(new Map());
   const loadedProjectIds = useRef<Set<string>>(new Set());
+  const projectConfigRef = useRef<ProjectConfig | null>(null);
+  const prefsReadyRef = useRef(false);
 
   const [mentionSearch, setMentionSearch] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
@@ -73,11 +89,26 @@ export function NewTaskView({
 
   // Load default agent and permission mode from project config when project changes
   useEffect(() => {
-    invoke<{ agent: { default: string; default_permission_mode?: string } }>(
-      "read_project_config",
-      { projectPath: project.path },
-    )
+    let cancelled = false;
+    prefsReadyRef.current = false;
+    const fallbackConfig: ProjectConfig = {
+      agent: {
+        default: "claude",
+        default_permission_mode: "ask",
+        default_plan_mode: false,
+        prompt_prefix: "",
+        claude_version: "",
+        codex_version: "",
+      },
+      git: {
+        commit_prompt: "",
+      },
+    };
+
+    invoke<ProjectConfig>("read_project_config", { projectPath: project.path })
       .then((cfg) => {
+        if (cancelled) return;
+        projectConfigRef.current = cfg;
         const defaultAgent = cfg.agent.default;
         if (defaultAgent === "claude" || defaultAgent === "codex") {
           setAgent(defaultAgent);
@@ -86,10 +117,65 @@ export function NewTaskView({
         if (defaultPerm === "ask" || defaultPerm === "auto_edit" || defaultPerm === "full_access") {
           setPermMode(defaultPerm);
         }
+        setPlanMode(Boolean(cfg.agent.default_plan_mode));
       })
-      .catch(() => {});
+      .catch(() => {
+        if (cancelled) return;
+        projectConfigRef.current = fallbackConfig;
+        setAgent("claude");
+        setPermMode("ask");
+        setPlanMode(false);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          prefsReadyRef.current = true;
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project.id]);
+
+  useEffect(() => {
+    if (!prefsReadyRef.current) return;
+    let cancelled = false;
+    const persistDefaults = async () => {
+      const latestConfig = await invoke<ProjectConfig>("read_project_config", {
+        projectPath: project.path,
+      }).catch(() => projectConfigRef.current);
+      if (cancelled || !latestConfig) return;
+
+      const currentAgent = latestConfig.agent.default;
+      const currentPlanMode = Boolean(latestConfig.agent.default_plan_mode);
+      if (currentAgent === agent && currentPlanMode === planMode) {
+        projectConfigRef.current = latestConfig;
+        return;
+      }
+
+      const nextConfig: ProjectConfig = {
+        ...latestConfig,
+        agent: {
+          ...latestConfig.agent,
+          default: agent,
+          default_plan_mode: planMode,
+        },
+      };
+      projectConfigRef.current = nextConfig;
+      await invoke("write_project_config", { projectPath: project.path, config: nextConfig }).catch(
+        (e: unknown) => {
+          if (!cancelled) {
+            showToast(`Failed to save task defaults for this project: ${String(e)}`, "warning");
+          }
+        },
+      );
+    };
+
+    void persistDefaults();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, planMode, project.path, showToast]);
 
   const [hasMdFile, setHasMdFile] = useState<boolean | null>(null);
 

--- a/src/components/RunningView.tsx
+++ b/src/components/RunningView.tsx
@@ -5,7 +5,7 @@ import { permissionModeLabel } from "../types";
 import { StatusIcon } from "./StatusIcon";
 import { TerminalView } from "./TerminalView";
 import { SessionView } from "./SessionView";
-import { shortenPath, getUsageColor } from "../utils";
+import { getUsageColor } from "../utils";
 import { useUsageSnapshot } from "../hooks/useUsageSnapshot";
 import { ENABLE_USAGE_INSIGHTS } from "../platform";
 import s from "../styles";
@@ -232,6 +232,10 @@ export function RunningView({
             {task.agent === "claude" ? "✦ Claude Code" : "⬡ Codex"} ·{" "}
             {permissionModeLabel(task.permissionMode, task.agent)}
           </span>
+          <span>·</span>
+          <span style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" }}>
+            Task #{task.id}
+          </span>
           {ENABLE_USAGE_INSIGHTS && usageSnapshot && (task.agent === "claude"
             ? usageSnapshot.claude.status === "available" && (
                 <>
@@ -255,22 +259,6 @@ export function RunningView({
               )
           )}
         </div>
-        {sessionPath && (
-          <div
-            title={sessionPath}
-            style={{
-              marginTop: 4,
-              fontSize: 11,
-              color: "var(--text-muted)",
-              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            Session file: {shortenPath(sessionPath)}
-          </div>
-        )}
         {metrics && (
           <div
             style={{

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -8,6 +8,7 @@ interface ProjectConfig {
   agent: {
     default: string;
     default_permission_mode: string;
+    default_plan_mode?: boolean;
     prompt_prefix: string;
     claude_version: string;
     codex_version: string;
@@ -174,6 +175,7 @@ function ProjectSettings({ projectPath, onClose }: { projectPath: string; onClos
           agent: {
             default: agentDefault,
             default_permission_mode: defaultPermissionMode,
+            default_plan_mode: config?.agent.default_plan_mode ?? false,
             prompt_prefix: promptPrefix,
             claude_version: claudeVersion,
             codex_version: codexVersion,

--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -195,8 +195,10 @@ export function WelcomePage({
                 filtered.map((p) => {
                   const [from] = getAvatarGradient(p.name);
                   return (
-                    <button
+                    <div
                       key={p.id}
+                      role="button"
+                      tabIndex={0}
                       style={{
                         ...s.projectItem,
                         background: hov === p.id ? "var(--bg-hover)" : "transparent",
@@ -205,6 +207,12 @@ export function WelcomePage({
                       onMouseEnter={() => setHov(p.id)}
                       onMouseLeave={() => setHov(null)}
                       onClick={() => onProjectClick(p)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onProjectClick(p);
+                        }
+                      }}
                     >
                       <ProjectAvatar
                         name={p.name}
@@ -227,6 +235,7 @@ export function WelcomePage({
                       )}
 
                       <button
+                        type="button"
                         style={{
                           marginLeft: 8,
                           padding: "4px 6px",
@@ -255,7 +264,7 @@ export function WelcomePage({
                       >
                         <Trash2 size={14} strokeWidth={1.8} />
                       </button>
-                    </button>
+                    </div>
                   );
                 })
               )}

--- a/src/components/task-panel/TaskListItem.tsx
+++ b/src/components/task-panel/TaskListItem.tsx
@@ -41,7 +41,12 @@ export const TaskListItem = memo(
             {displayTitle.slice(0, 70)}
             {displayTitle.length > 70 ? "…" : ""}
           </div>
-          <div style={s.taskCardSub}>{STATUS_LABEL[task.status]}</div>
+          <div style={s.taskCardSub}>
+            {STATUS_LABEL[task.status]}
+            <span style={{ marginLeft: 8, fontFamily: "var(--font-mono)", fontSize: 11 }}>
+              #{task.id}
+            </span>
+          </div>
         </div>
         <button
           type="button"


### PR DESCRIPTION
# PR 总结

  ## 背景与目标
  本次改动围绕三个方向展开：
  1. 提升任务会话恢复能力，修复重启后任务状态与会话关联不完整的问题。
  2. 增强代理网络配置能力，支持全局 `ALL_PROXY`。
  3. 优化默认体验与可维护性，增加开关控制并清理调试噪音。

  ---

  ## 核心改动

  ## 1) 应用级设置增强（代理 + 会话回填开关）
  - 新增 `AppSettings.proxy_url`，支持 `http/https/socks5/socks5h`。
  - 新增 `AppSettings.enable_session_backfill`，默认 `false`（即默认不开启回填）。
  - 保存设置时增加代理 URL 合法性校验。
  - 自动探测路径时保留已有 `proxy_url` 与 `enable_session_backfill` 值。

  涉及文件：
  - `src-tauri/src/app_settings.rs`
  - `src/components/AppSettingsDialog.tsx`

  ---

  ## 2) 全局代理能力落地（仅使用 ALL_PROXY）
  - 进程命令路径注入代理环境：
  - `git` 命令（同步与异步）注入 `ALL_PROXY`。
  - 文件系统里依赖 `git` 的路径也注入 `ALL_PROXY`。
  - HTTP 请求路径注入代理：
  - 通知拉取（notification）请求走代理。
  - usage 快照里的 HTTP client 支持代理构建。

  涉及文件：
  - `src-tauri/src/git.rs`
  - `src-tauri/src/fs.rs`
  - `src-tauri/src/notification.rs`
  - `src-tauri/src/usage.rs`

  ---

  ## 3) 项目级默认值记忆（模型 + plan mode）
  - 项目配置新增 `agent.default_plan_mode`，默认 `false`。
  - 新任务页读取并应用项目默认：
  - 默认模型 `agent.default`
  - 默认权限 `agent.default_permission_mode`
  - 默认 plan mode `agent.default_plan_mode`
  - 当用户切换模型或 plan mode 时，写回项目配置，作为后续默认值。
  - 修复并发覆盖风险：写回前先读最新配置再 merge，避免覆盖设置页刚修改的字段。

  涉及文件：
  - `src-tauri/src/config.rs`
  - `src/components/NewTaskView.tsx`
  - `src/components/SettingsDialog.tsx`

  ---

  ## 4) 会话恢复能力增强
  - 启动时恢复流程增强：
  - 先把残留活动态任务修正为 `cancelled`。
  - 对“有 sessionId 但缺 sessionPath”的任务，补查路径。
  - 对 codex 任务增加可选回填逻辑（受 `enable_session_backfill` 控制，默认关闭）。
  - 新增 `recover_codex_sessions_for_tasks` 命令：
  - 从 session 文件元数据做兜底恢复。
  - 匹配策略收紧，降低误绑。
  - 放入 `spawn_blocking` 执行，降低主线程阻塞风险。
  - `/status` 发现链路增强：
  - 更早触发 codex `/status`。
  - 若未抓到 Session ID，则尝试用近期 session 文件兜底发现。
  - 统一 `task-session` 事件发射辅助函数，减少重复逻辑。

  涉及文件：
  - `src-tauri/src/session.rs`
  - `src-tauri/src/lib.rs`
  - `src/App.tsx`

  ---

  ## 5) UI 与可用性修复
  - 修复 `button` 嵌套 `button` 的 DOM 结构错误（hydration warning）。
  - 外层改为可键盘访问容器（`role="button"` + `tabIndex` + Enter/Space）。
  - 列表/运行头增加 `Task #id` 便于定位。
  - 去除调试阶段临时展示的 `sessionId/sessionPath/search pattern` 文字。
  - 移除前端与后端调试日志噪音。

  涉及文件：
  - `src/components/WelcomePage.tsx`
  - `src/components/RunningView.tsx`
  - `src/components/task-panel/TaskListItem.tsx`
  - `src/App.tsx`
  - `src-tauri/src/session.rs`

  ---

  ## 行为变化说明
  - 默认行为变化：
  - 会话回填默认关闭，需要在 App Settings 中手动开启。
  - 可见性变化：
  - 右侧运行区与任务列表不再显示调试用 session 路径提示。
  - 稳定性变化：
  - 重启后“残留 running”会被修正，避免假运行态卡住 UI。
  - 网络行为变化：
  - 配置代理后，内部命令与 HTTP 请求统一走 `ALL_PROXY`。

  ---

  ## 风险与回滚点
  - 风险：
  - 会话回填属于兜底能力，开启后仍可能受历史数据质量影响。
  - 代理配置错误会导致相关网络请求失败，但保存时已有格式校验。
  - 回滚点：
  - 关闭 `enable_session_backfill` 即可停用回填。
  - 清空 `proxy_url` 即可恢复直连行为。

  ---

  ## 验证情况
  - 已执行：`pnpm build` 通过。
  - 未执行：Rust 侧本地编译检查（当前环境无 `cargo`）。

  ---

  ## 变更文件列表
  - `src-tauri/src/app_settings.rs`
  - `src-tauri/src/config.rs`
  - `src-tauri/src/fs.rs`
  - `src-tauri/src/git.rs`
  - `src-tauri/src/lib.rs`
  - `src-tauri/src/notification.rs`
  - `src-tauri/src/session.rs`
  - `src-tauri/src/usage.rs`
  - `src/App.tsx`
  - `src/components/AppSettingsDialog.tsx`
  - `src/components/NewTaskView.tsx`
  - `src/components/RunningView.tsx`
  - `src/components/SettingsDialog.tsx`
  - `src/components/WelcomePage.tsx`
  - `src/components/task-panel/TaskListItem.tsx`