### PR TITLE
ci: add Linux x86_64 and ARM64 builds (deb + rpm)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -3,14 +3,40 @@ name: Release Desktop Builds
 on:
   push:
     tags:
-      - "*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  verify-version:
+    name: Verify version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check tag matches package.json / Cargo.toml / tauri.conf.json
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(jq -r .version package.json)
+          TAURI=$(jq -r .version src-tauri/tauri.conf.json)
+          CARGO=$(awk -F\" '/^version[[:space:]]*=/ {print $2; exit}' src-tauri/Cargo.toml)
+          echo "tag=$TAG package.json=$PKG tauri.conf.json=$TAURI Cargo.toml=$CARGO"
+          if [ "$TAG" != "$PKG" ] || [ "$TAG" != "$TAURI" ] || [ "$TAG" != "$CARGO" ]; then
+            echo "::error::Version mismatch — tag '$TAG' must equal package.json ($PKG), tauri.conf.json ($TAURI), and Cargo.toml ($CARGO)"
+            exit 1
+          fi
+
   build:
     name: Build ${{ matrix.name }}
+    needs: verify-version
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -36,10 +62,27 @@ jobs:
             runner: macos-15
             target: aarch64-apple-darwin
             bundle_args: --bundles dmg
+          - name: Linux x86_64
+            artifact_name: linux-x86_64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            bundle_args: --bundles deb,rpm
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -78,11 +121,15 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
             src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
             src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
 
   release:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Download build artifacts


### PR DESCRIPTION
- Add Ubuntu 22.04 runners for x86_64 and ARM64
- Install WebKit2GTK, GTK3, libsoup3 system dependencies
- Bundle as .deb and .rpm packages
- Add workflow_dispatch for manual testing
- Guard release job to only run on tag pushes