### PR TITLE
fix: 重启后点击运行中任务自动恢复 PTY 连接

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,13 +29,15 @@ pub struct TaskManager {
     pub(crate) codex_sessions: Mutex<HashMap<String, CodexSessionInfo>>,
     pub(crate) claude_sessions: Mutex<HashMap<String, ClaudeSessionInfo>>,
     pub(crate) claimed_session_paths: Mutex<HashSet<String>>,
+    /// Tracks tasks currently starting up to prevent duplicate run/resume.
+    pub(crate) pending_resumes: Mutex<HashSet<String>>,
     /// Persistent `codex app-server` process reused across `read_usage_snapshot` calls.
     pub(crate) codex_rpc: Arc<Mutex<Option<CodexRpcClient>>>,
 }
 
 impl TaskManager {
-    /// Atomically remove a task/shell from all PTY maps (masters, writers, children).
-    /// Locks are acquired in a fixed order to prevent deadlocks.
+    /// Atomically remove a task/shell from all PTY maps (masters, writers, children)
+    /// and the pending_resumes set. Locks are acquired in a fixed order to prevent deadlocks.
     pub(crate) fn remove_pty_handles(&self, id: &str) {
         let mut masters = self.pty_masters.lock();
         let mut writers = self.pty_writers.lock();
@@ -43,6 +45,7 @@ impl TaskManager {
         masters.remove(id);
         writers.remove(id);
         children.remove(id);
+        self.pending_resumes.lock().remove(id);
     }
 }
 
@@ -64,6 +67,7 @@ pub fn run() {
             codex_sessions: Mutex::new(HashMap::new()),
             claude_sessions: Mutex::new(HashMap::new()),
             claimed_session_paths: Mutex::new(HashSet::new()),
+            pending_resumes: Mutex::new(HashSet::new()),
             codex_rpc: Arc::new(Mutex::new(None)),
         })
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -11,7 +11,7 @@ use crate::session::{spawn_resume_session_watcher, spawn_status_session_watcher}
 use crate::TaskManager;
 
 const SESSION_WAIT_POLL: Duration = Duration::from_millis(50);
-const SESSION_WAIT_MAX: Duration = Duration::from_millis(500);
+const SESSION_WAIT_MAX: Duration = Duration::from_secs(5);
 const PTY_READ_BUFFER_SIZE: usize = 32 * 1024;
 const PTY_EMIT_FLUSH_INTERVAL: Duration = Duration::from_millis(16);
 const PTY_EMIT_MAX_BATCH_BYTES: usize = 64 * 1024;
@@ -35,7 +35,7 @@ fn has_task_session(app: &AppHandle, task_id: &str, is_codex: bool) -> bool {
     }
 }
 
-/// 任务结束后，等待会话注册完成，最长等待 500ms。
+/// 任务结束后，等待会话注册完成，最长等待 5s。
 fn wait_for_session(app: &AppHandle, task_id: &str, is_codex: bool) {
     let deadline = Instant::now() + SESSION_WAIT_MAX;
     while Instant::now() < deadline {
@@ -165,14 +165,58 @@ fn setup_env(cmd: &mut CommandBuilder) {
     cmd.env("COLORTERM", "truecolor");
 }
 
-/// 将 PTY master/writer/child 注册到 TaskManager 的三个 HashMap 中。
+/// RAII 守卫：PTY 注册失败时自动从 `pending_resumes` 移除 task_id。
+struct PendingGuard<'a> {
+    tm: &'a TaskManager,
+    task_id: String,
+    done: bool,
+}
+
+impl<'a> Drop for PendingGuard<'a> {
+    fn drop(&mut self) {
+        if !self.done {
+            self.tm.pending_resumes.lock().remove(&self.task_id);
+        }
+    }
+}
+
+/// spawn_command 成功后、注册进 TaskManager 前失败时自动 kill child。
+struct ChildGuard {
+    child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+}
+
+impl ChildGuard {
+    fn new(child: Box<dyn portable_pty::Child + Send + Sync>) -> Self {
+        Self { child: Some(child) }
+    }
+    fn into_inner(mut self) -> Box<dyn portable_pty::Child + Send + Sync> {
+        self.child.take().expect("child already taken")
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+        }
+    }
+}
+
+/// run_task / resume_task 的返回值，告诉前端这次是否真正启动了 PTY。
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStartResult {
+    pub started: bool,
+}
+
+/// 将 PTY master/writer/child 注册到 TaskManager。
 fn register_pty_handles(
     task_manager: &TaskManager,
     id: &str,
     master: Box<dyn portable_pty::MasterPty + Send>,
     writer: Box<dyn Write + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
-) -> Result<(), String> {
+) {
     task_manager
         .pty_masters
         .lock()
@@ -185,7 +229,6 @@ fn register_pty_handles(
         .child_handles
         .lock()
         .insert(id.to_string(), Arc::new(std::sync::Mutex::new(child)));
-    Ok(())
 }
 
 #[derive(Clone, Copy)]
@@ -420,7 +463,20 @@ pub async fn run_task(
     cols: Option<u16>,
     rows: Option<u16>,
     on_output: Channel<String>,
-) -> Result<(), String> {
+) -> Result<TaskStartResult, String> {
+    // 原子去重：已在启动中则直接返回。
+    {
+        let tm = app.state::<TaskManager>();
+        if !tm.pending_resumes.lock().insert(task_id.clone()) {
+            return Ok(TaskStartResult { started: false });
+        }
+    }
+    let mut guard = PendingGuard {
+        tm: &task_manager,
+        task_id: task_id.clone(),
+        done: false,
+    };
+
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: rows.unwrap_or(50),
@@ -486,10 +542,12 @@ pub async fn run_task(
     }
 
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let child_guard = ChildGuard::new(child);
     drop(pair.slave);
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
-    register_pty_handles(&task_manager, &task_id, pair.master, writer, child)?;
+    register_pty_handles(&task_manager, &task_id, pair.master, writer, child_guard.into_inner());
+    guard.done = true;
 
     let _ = app.emit(
         "task-status",
@@ -520,7 +578,7 @@ pub async fn run_task(
     );
     spawn_exit_monitor(app, task_id, project_path, is_codex);
 
-    Ok(())
+    Ok(TaskStartResult { started: true })
 }
 
 #[tauri::command]
@@ -589,7 +647,20 @@ pub async fn resume_task(
     cols: Option<u16>,
     rows: Option<u16>,
     on_output: Channel<String>,
-) -> Result<(), String> {
+) -> Result<TaskStartResult, String> {
+    // 原子去重：已在恢复中则直接返回。
+    {
+        let tm = app.state::<TaskManager>();
+        if !tm.pending_resumes.lock().insert(task_id.clone()) {
+            return Ok(TaskStartResult { started: false });
+        }
+    }
+    let mut guard = PendingGuard {
+        tm: &task_manager,
+        task_id: task_id.clone(),
+        done: false,
+    };
+
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: rows.unwrap_or(50),
@@ -620,10 +691,12 @@ pub async fn resume_task(
     }
 
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let child_guard = ChildGuard::new(child);
     drop(pair.slave);
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
-    register_pty_handles(&task_manager, &task_id, pair.master, writer, child)?;
+    register_pty_handles(&task_manager, &task_id, pair.master, writer, child_guard.into_inner());
+    guard.done = true;
 
     let _ = app.emit(
         "task-status",
@@ -654,7 +727,7 @@ pub async fn resume_task(
     );
     spawn_exit_monitor(app, task_id, project_path, is_codex);
 
-    Ok(())
+    Ok(TaskStartResult { started: true })
 }
 
 #[tauri::command]
@@ -729,10 +802,11 @@ pub async fn open_shell(
     setup_env(&mut cmd);
 
     let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let child_guard = ChildGuard::new(child);
     drop(pair.slave);
     let reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
     let writer = pair.master.take_writer().map_err(|e| e.to_string())?;
-    register_pty_handles(&task_manager, &shell_id, pair.master, writer, child)?;
+    register_pty_handles(&task_manager, &shell_id, pair.master, writer, child_guard.into_inner());
 
     // Shell 退出后清理 TaskManager 中的残留句柄
     let app_cleanup = app.clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { open as openDialog, confirm } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -96,6 +96,7 @@ function App() {
   const [projectViews, setProjectViews] = useState<Record<string, ProjectViewState>>({});
   const [mountedProjectIds, setMountedProjectIds] = useState<string[]>([]);
   const [taskRunCounts, setTaskRunCounts] = useState<Record<string, number>>({});
+  const resumingTaskIds = useRef<Set<string>>(new Set());
 
   const tm = useTerminalManager();
 
@@ -179,11 +180,12 @@ function App() {
       const chunks = await Promise.all(
         loadedProjects.map((p) => invoke<Task[]>("load_project_tasks", { projectId: p.id })),
       );
-      setTasks(chunks.flat());
+      const allTasks = chunks.flat();
+      setTasks(allTasks);
     }
 
     init().catch(console.error);
-  }, []);
+  }, [tm.terminalSizeRef]);
 
   // Tauri event listeners (agent-output is handled inside useTerminalManager)
   useEffect(() => {
@@ -332,14 +334,17 @@ function App() {
     });
   }
 
-  function handleResumeTask(taskId: string) {
+  function handleResumeTask(taskId: string): Promise<void> {
+    if (resumingTaskIds.current.has(taskId)) return Promise.resolve();
+    resumingTaskIds.current.add(taskId);
+
     const task = tasks.find((t) => t.id === taskId);
     const sessionId = task?.agent === "codex" ? task.codexSessionId : task?.claudeSessionId;
-    if (!task || !sessionId) return;
+    if (!task || !sessionId) { resumingTaskIds.current.delete(taskId); return Promise.resolve(); }
     const project = projects.find((p) => p.id === task.projectId);
-    if (!project) return;
+    if (!project) { resumingTaskIds.current.delete(taskId); return Promise.resolve(); }
 
-    // Reset task status, clear buffer, and bump run counter to remount the terminal
+    // Reset terminal before invoke so data from the new PTY flows into a clean buffer
     setTasks((prev) => {
       const next = prev.map((t) =>
         t.id === taskId
@@ -352,7 +357,7 @@ function App() {
     tm.resetTaskTerminal(taskId);
     setTaskRunCounts((prev) => ({ ...prev, [taskId]: (prev[taskId] ?? 0) + 1 }));
 
-    invoke("resume_task", {
+    return invoke<{ started: boolean }>("resume_task", {
       taskId,
       projectPath: project.path,
       agent: task.agent,
@@ -362,10 +367,14 @@ function App() {
       cols: tm.terminalSizeRef.current.cols,
       rows: tm.terminalSizeRef.current.rows,
       onOutput: tm.createOutputChannel(taskId),
+    }).then((result) => {
+      if (!result.started) return;
     }).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       tm.writeErrorToTerminal(taskId, `\r\nError: ${msg}\r\n`);
       updateTaskStatus(taskId, "failed", undefined, msg);
+    }).finally(() => {
+      resumingTaskIds.current.delete(taskId);
     });
   }
 
@@ -592,9 +601,18 @@ function App() {
               onNewTask={() =>
                 updateProjectView(project.id, { selectedTaskId: null, isNewTask: true })
               }
-              onSelectTask={(id) =>
-                updateProjectView(project.id, { selectedTaskId: id, isNewTask: false })
-              }
+              onSelectTask={(id) => {
+                updateProjectView(project.id, { selectedTaskId: id, isNewTask: false });
+                // Auto-resume orphaned active tasks (app was restarted)
+                const task = tasks.find((t) => t.id === id);
+                if (task && isActiveTaskStatus(task.status)) {
+                  const sessionId =
+                    task.agent === "codex" ? task.codexSessionId : task.claudeSessionId;
+                  if (sessionId && !tm.hasTaskBuffer(id)) {
+                    handleResumeTask(id);
+                  }
+                }
+              }}
               onDeleteTask={handleDeleteTask}
               onDeleteAllTasks={() => handleDeleteAllTasks(project)}
               onToggleTaskStar={handleToggleTaskStar}

--- a/src/hooks/useTerminalManager.ts
+++ b/src/hooks/useTerminalManager.ts
@@ -267,8 +267,14 @@ export function useTerminalManager() {
     };
   }, []);
 
+  const hasTaskBuffer = useCallback((taskId: string) => {
+    const buf = taskBufferRef.current[taskId];
+    return !!buf && buf.totalLen > 0;
+  }, []);
+
   return {
     terminalSizeRef,
+    hasTaskBuffer,
     resetTaskTerminal,
     removeTaskBuffers,
     writeErrorToTerminal,


### PR DESCRIPTION
## 问题

关闭 Nezha 后重新打开，点击之前的运行中任务会白屏，终端区域一片空白，没有任何操作入口。

**根因**：应用关闭后 PTY 连接丢失，重启后任务仍标记为 running 状态，但没有终端数据。同时 `SESSION_WAIT_MAX`（500ms）过短，导致部分任务的会话路径未被持久化。

## 修改

- `src/App.tsx`：用户点击选中活跃任务时，检测该任务是否有终端缓冲区数据，若无则说明是重启后的孤儿任务，自动调用 `resume_task` 恢复 PTY 连接（点一个恢复一个，不会批量拉起所有任务）
- `src/hooks/useTerminalManager.ts`：新增 `hasTaskBuffer()` 方法，判断任务是否有终端缓冲区数据
- `src-tauri/src/pty.rs`：`SESSION_WAIT_MAX` 从 500ms 增大到 5s，减少会话发现竞态失败

## 测试

1. `pnpm tauri dev` 启动，创建任务并等待运行
2. 关闭应用后重新打开
3. 点击之前的运行中任务 → 终端自动恢复连接，输出继续流动
4. 确认正常运行中的新任务不受影响（取消按钮正常显示）
5. `pnpm lint` / `pnpm build` 均通过