### PR TITLE
fix: support macOS Chinese IME symbol input in terminals

### DIFF
--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -13,6 +13,7 @@ import {
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
+import { attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import { Plus, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { useI18n } from "../i18n";
 import "@xterm/xterm/css/xterm.css";
@@ -95,6 +96,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       terminalRef.current = term;
       fitAddonRef.current = fitAddon;
       term.open(container);
+      const disposeInputFix = attachMacWebKitShiftInputFix(term);
       loadWebglAddon(term);
 
       const fit = () => {
@@ -186,6 +188,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         terminalRef.current = null;
         fitAddonRef.current = null;
+        disposeInputFix();
         term.dispose();
         invoke("kill_shell", { shellId }).catch(() => {});
       };

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -11,6 +11,7 @@ import {
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
+import { attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -75,6 +76,7 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
+    const disposeInputFix = attachMacWebKitShiftInputFix(term);
     loadWebglAddon(term);
 
     const size = safeFit(fitAddon, term);
@@ -163,6 +165,7 @@ export function TerminalView({
       }
       onRegisterRef.current(null);
       fitAddonRef.current = null;
+      disposeInputFix();
       disposeSmartCopy();
       disposeOnData.dispose();
       if (resizeTimer) clearTimeout(resizeTimer);

--- a/src/components/terminalInputFix.ts
+++ b/src/components/terminalInputFix.ts
@@ -1,0 +1,64 @@
+import type { Terminal } from "@xterm/xterm";
+import { APP_PLATFORM } from "../platform";
+
+type TerminalWithInput = Pick<Terminal, "input" | "textarea">;
+
+function isMacWebKit(): boolean {
+  if (APP_PLATFORM !== "macos" || typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  const isWebKit = ua.includes("AppleWebKit");
+  return isWebKit;
+}
+
+function getPrintableSymbolInput(data: string | null): string | null {
+  if (data === null || data.length === 0) return null;
+  if (data.length > 8) return null;
+  if (!/^[\p{P}\p{S}]+$/u.test(data)) return null;
+  return data;
+}
+
+function isSymbolInputType(inputType: string): boolean {
+  return inputType === "insertText" || inputType === "insertCompositionText";
+}
+
+export function attachMacWebKitShiftInputFix(term: TerminalWithInput): () => void {
+  if (!isMacWebKit() || !term.textarea) return () => {};
+
+  const textarea = term.textarea;
+  let keydownHandledByXterm: string | null = null;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    keydownHandledByXterm = null;
+    if (
+      event.keyCode !== 229 &&
+      event.shiftKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey &&
+      getPrintableSymbolInput(event.key) !== null
+    ) {
+      keydownHandledByXterm = event.key;
+    }
+  };
+
+  const handleBeforeInput = (event: InputEvent) => {
+    const symbol = getPrintableSymbolInput(event.data);
+    if (!isSymbolInputType(event.inputType) || symbol === null) {
+      return;
+    }
+    if (keydownHandledByXterm === symbol) {
+      keydownHandledByXterm = null;
+      return;
+    }
+    term.input(symbol);
+    event.preventDefault();
+  };
+
+  textarea.addEventListener("keydown", handleKeyDown);
+  textarea.addEventListener("beforeinput", handleBeforeInput);
+
+  return () => {
+    textarea.removeEventListener("keydown", handleKeyDown);
+    textarea.removeEventListener("beforeinput", handleBeforeInput);
+  };
+}


### PR DESCRIPTION
  This PR fixes a macOS-specific input issue in the xterm-based task Terminal and embedded Shell terminal when using a
  Chinese IME.

  On macOS, Tauri runs on WebKit/WKWebView. In this environment, some Chinese IME punctuation and symbol input is
  delivered through the helper textarea's `beforeinput` event instead of xterm's normal key handling path. As a result, the first symbol key press could be swallowed, requiring the user to press the same key twice.

  This change adds a small macOS WebKit-only input bridge for xterm terminals. It forwards short punctuation/symbol
  input from `beforeinput` into xterm while preserving the original text exactly. It does not convert full-width
  punctuation to half-width ASCII, so inputs such as `？`, `¥`, and `……` remain unchanged.

  ## File Changes

  ```text
  src/components/
  ├── terminalInputFix.ts          # Adds the macOS WebKit xterm input bridge
  ├── TerminalView.tsx             # Applies the fix to task terminals
  └── ShellTerminalPanel.tsx       # Applies the fix to embedded Shell terminals

  ### src/components/terminalInputFix.ts

  - Adds attachMacWebKitShiftInputFix().
  - Reuses the shared APP_PLATFORM platform detection and only attaches on macOS WebKit.
  - Listens to xterm's helper textarea beforeinput event.
  - For short punctuation/symbol-only input, forwards the original input text to term.input().
  - Ignores letters, numbers, whitespace, and regular IME text composition to avoid interfering with normal Chinese
    input.
  - Tracks symbol input already handled by xterm keydown to avoid duplicate sends.

  ### src/components/TerminalView.tsx

  - Attaches the macOS WebKit input fix after term.open(container).
  - Disposes the input fix during terminal cleanup.

  ### src/components/ShellTerminalPanel.tsx

  - Attaches the same input fix to embedded Shell terminal instances.
  - Disposes the input fix during shell terminal cleanup.

  ## Test Plan

  - pnpm exec tsc --noEmit
  - pnpm test
  - Manually verified in the macOS Tauri desktop app with Chinese IME symbol input, including ？, ¥, ……, and ：.

