### PR TITLE
feat: add AUR packaging and automated publish workflow

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,117 @@
+name: Publish AUR Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the leading v. Leave empty to derive it from the tag or latest project version.
+        required: false
+  release:
+    types:
+      - published
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    env:
+      PKGBASE: nezha-ide
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install packaging dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          pacman -Syu --noconfirm --needed base-devel git openssh curl jq
+          useradd --create-home --shell /bin/bash builder
+          install -d -o builder -g builder /tmp/aur-work
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ github.event.inputs.version || '' }}" ]; then
+            version='${{ github.event.inputs.version || '' }}'
+          elif [ "${GITHUB_EVENT_NAME}" = 'release' ]; then
+            version='${{ github.event.release.tag_name }}'
+            version="${version#v}"
+          elif [ "${GITHUB_REF_TYPE}" = 'tag' ] && [ -n "${GITHUB_REF_NAME}" ]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version=$(jq -r '.version' package.json)
+          fi
+
+          if [ -z "${version}" ] || [ "${version}" = 'null' ]; then
+            echo 'Unable to determine release version.' >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Update PKGBUILD for release version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version='${{ steps.version.outputs.version }}'
+          source_url="https://github.com/hanshuaikang/nezha/archive/refs/tags/v${version}.tar.gz"
+          archive_path="/tmp/${PKGBASE}-${version}.tar.gz"
+          checksum=$(curl -L "${source_url}" | tee "${archive_path}" | sha256sum | awk '{print $1}')
+
+          sed -i \
+            -e "s/^pkgver=.*/pkgver=${version}/" \
+            -e "s/^sha256sums=.*/sha256sums=('${checksum}')/" \
+            packaging/aur/PKGBUILD
+
+      - name: Generate .SRCINFO
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -o builder -g builder /tmp/aur-work/repo
+          cp -R . /tmp/aur-work/repo
+          chown -R builder:builder /tmp/aur-work/repo
+          su builder -c 'cd /tmp/aur-work/repo/packaging/aur && makepkg --printsrcinfo > .SRCINFO'
+          cp /tmp/aur-work/repo/packaging/aur/.SRCINFO packaging/aur/.SRCINFO
+
+      - name: Configure SSH for AUR
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -dm700 /root/.ssh
+          printf '%s\n' '${{ secrets.AUR_SSH_PRIVATE_KEY }}' > /root/.ssh/id_ed25519
+          printf '%s\n' '${{ secrets.AUR_KNOWN_HOSTS }}' > /root/.ssh/known_hosts
+          chmod 600 /root/.ssh/id_ed25519 /root/.ssh/known_hosts
+
+      - name: Publish changed packaging files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          aur_dir=/tmp/aur
+          git clone "ssh://aur@aur.archlinux.org/${PKGBASE}.git" "${aur_dir}"
+          cp packaging/aur/PKGBUILD packaging/aur/.SRCINFO "${aur_dir}/"
+
+          cd "${aur_dir}"
+
+          if git diff --quiet -- PKGBUILD .SRCINFO; then
+            echo 'No AUR packaging changes detected.'
+            exit 0
+          fi
+
+          git add PKGBUILD .SRCINFO
+          git -c user.name='github-actions[bot]' -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -m "Update ${PKGBASE} to ${{ steps.version.outputs.version }}"
+          git push origin HEAD

--- a/docs/aur.md
+++ b/docs/aur.md
@@ -1,0 +1,61 @@
+# AUR Packaging
+
+This repository includes AUR packaging for the stable source package `nezha-ide` under `packaging/aur/`.
+
+## Package Naming
+
+The packaging uses `nezha-ide` as the AUR package name.
+
+At the time this change was prepared, AUR searches for `nezha`, `nezha-ide`, `nezha-git`, and `nezha-bin` returned no matches. If the upstream maintainers prefer a different final package name, update `pkgbase`, `pkgname`, workflow `PKGBASE`, and the published AUR repository URL together.
+
+## GitHub Secrets
+
+The publish workflow expects these repository secrets:
+
+- `AUR_SSH_PRIVATE_KEY`: SSH private key for the AUR maintainer account.
+- `AUR_KNOWN_HOSTS`: Output of `ssh-keyscan aur.archlinux.org`.
+
+Do not commit private keys, tokens, or AUR credentials into the repository.
+
+## Workflow Behavior
+
+`.github/workflows/publish-aur.yml`:
+
+- always supports `workflow_dispatch`
+- publishes on GitHub `release.published`
+- also publishes on `v*` tag pushes
+- updates `packaging/aur/PKGBUILD` with the release version and source tarball checksum
+- regenerates `packaging/aur/.SRCINFO` with `makepkg --printsrcinfo`
+- pushes only when `PKGBUILD` or `.SRCINFO` actually changed
+
+The workflow is intentionally separate from `.github/workflows/checks.yml` so routine CI remains unchanged.
+
+## Local Verification
+
+Project checks:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Arch packaging checks inside a container:
+
+```bash
+podman run --rm -it -v "$PWD:/src" -w /src archlinux:latest bash
+pacman -Syu --noconfirm --needed base-devel git pnpm nodejs rust cargo pkgconf gtk3 webkit2gtk-4.1 libayatana-appindicator librsvg openssl
+useradd --create-home --shell /bin/bash builder
+chown -R builder:builder /src
+cd packaging/aur
+su builder -c 'cd /src/packaging/aur && makepkg --printsrcinfo > .SRCINFO && makepkg -si --noconfirm'
+```
+
+If your environment uses Docker instead of Podman, the same steps work with `docker run`.
+
+## Notes
+
+- The package builds from the GitHub source tarball for `v${pkgver}`.
+- `pnpm tauri build --no-bundle` is used so the package installs the real `nezha` binary rather than relying on an AppImage.
+- The desktop entry and icons are installed into standard system paths during packaging.

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,27 @@
+pkgbase = nezha-ide
+	pkgdesc = Agent-first desktop IDE for parallel AI coding workflows
+	pkgver = 0.3.2
+	pkgrel = 1
+	url = https://github.com/hanshuaikang/nezha
+	arch = x86_64
+	arch = aarch64
+	license = GPL-3.0-only
+	makedepends = cargo
+	makedepends = nodejs
+	makedepends = pkgconf
+	makedepends = pnpm
+	makedepends = rust
+	depends = gtk3
+	depends = hicolor-icon-theme
+	depends = libayatana-appindicator
+	depends = librsvg
+	depends = openssl
+	depends = webkit2gtk-4.1
+	provides = nezha
+	conflicts = nezha
+	conflicts = nezha-git
+	conflicts = nezha-bin
+	source = nezha-ide-0.3.2.tar.gz::https://github.com/hanshuaikang/nezha/archive/refs/tags/v0.3.2.tar.gz
+	sha256sums = 3cf3b9e9991318e3790944e57933a7f0bff91de8edf7bc4210cba136780d822b
+
+pkgname = nezha-ide

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,63 @@
+pkgbase=nezha-ide
+pkgname=nezha-ide
+pkgver=0.3.2
+pkgrel=1
+pkgdesc='Agent-first desktop IDE for parallel AI coding workflows'
+arch=('x86_64' 'aarch64')
+url='https://github.com/hanshuaikang/nezha'
+license=('GPL-3.0-only')
+depends=(
+  'gtk3'
+  'hicolor-icon-theme'
+  'libayatana-appindicator'
+  'librsvg'
+  'openssl'
+  'webkit2gtk-4.1'
+)
+makedepends=(
+  'cargo'
+  'nodejs'
+  'pkgconf'
+  'pnpm'
+  'rust'
+)
+provides=('nezha')
+conflicts=('nezha' 'nezha-git' 'nezha-bin')
+source=("${pkgbase}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('3cf3b9e9991318e3790944e57933a7f0bff91de8edf7bc4210cba136780d822b')
+
+build() {
+  cd "${srcdir}/nezha-${pkgver}"
+
+  export CARGO_TARGET_DIR="${srcdir}/target"
+  export npm_config_cache="${srcdir}/npm-cache"
+  export PNPM_HOME="${srcdir}/pnpm-home"
+
+  pnpm install --frozen-lockfile
+  pnpm tauri build --no-bundle
+}
+
+package() {
+  cd "${srcdir}/nezha-${pkgver}"
+
+  install -Dm755 "${srcdir}/target/release/nezha" "${pkgdir}/usr/bin/nezha"
+
+  install -Dm644 "src-tauri/icons/32x32.png" \
+    "${pkgdir}/usr/share/icons/hicolor/32x32/apps/nezha.png"
+  install -Dm644 "src-tauri/icons/128x128.png" \
+    "${pkgdir}/usr/share/icons/hicolor/128x128/apps/nezha.png"
+
+  install -Dm644 /dev/stdin "${pkgdir}/usr/share/applications/nezha.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Nezha
+Comment=Agent-first desktop IDE for parallel AI coding workflows
+Exec=nezha
+Icon=nezha
+Terminal=false
+Categories=Development;IDE;
+StartupWMClass=Nezha
+EOF
+
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
## Summary
- add a stable AUR source package under `packaging/aur/` using the `nezha-ide` package name
- add a dedicated GitHub Actions workflow to update `PKGBUILD`, regenerate `.SRCINFO`, and publish changes to AUR
- document the required GitHub secrets and local Arch verification steps

## Details
This change adds upstream-maintained AUR packaging for Nezha without changing the existing `checks.yml` workflow.

Packaging choices:
- uses `nezha-ide` as the AUR package name
- builds from the GitHub release source tarball instead of any prebuilt Linux artifact
- uses `pnpm tauri build --no-bundle` so the package installs the real `nezha` binary
- installs a desktop entry and icons into standard system paths
- declares Arch runtime dependencies using current package names such as `webkit2gtk-4.1`, `gtk3`, `libayatana-appindicator`, `librsvg`, and `openssl`

Workflow choices:
- supports `workflow_dispatch`
- also runs on `release.published` and `v*` tag pushes
- derives `pkgver` from the release/tag, strips the leading `v`, refreshes the source tarball checksum, regenerates `.SRCINFO`, and pushes only when there is an actual diff in the AUR repo
- uses `AUR_SSH_PRIVATE_KEY` and `AUR_KNOWN_HOSTS` secrets only; no credentials are committed to the repository

## Package Name Note
At the time this PR was prepared, AUR searches for `nezha`, `nezha-ide`, `nezha-git`, and `nezha-bin` returned no matches. I used `nezha-ide` as the default stable source package name per the requested naming strategy, but this can be renamed before merge if maintainers prefer a different final AUR package base.

## Verification
Ran locally:
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `makepkg --printsrcinfo`

I also confirmed that the repository's current Tauri CLI supports `pnpm tauri build --no-bundle`.

I was not able to complete a full Arch container build in this environment because `pacman` could not reach the Arch mirrors during container setup:
- `failed to retrieve core.db/extra.db ... Could not connect to server`

So this PR keeps the packaging/workflow foundation small and reviewable, without making unrelated Linux support changes to the application itself.