### PR TITLE
fix: stabilize linux ime input handling

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -63,7 +63,6 @@ fn finalize_task_exit(
     {
         let tm = app.state::<TaskManager>();
         tm.remove_pty_handles(task_id);
-
         let codex_info = tm.codex_sessions.lock().remove(task_id);
         let codex_path = codex_info.map(|info| info.session_path);
         let claude_info = tm.claude_sessions.lock().remove(task_id);
@@ -650,9 +649,7 @@ pub async fn send_input(
 ) -> Result<(), String> {
     let mut writers = task_manager.pty_writers.lock();
     if let Some(writer) = writers.get_mut(&task_id) {
-        writer
-            .write_all(data.as_bytes())
-            .map_err(|e| e.to_string())?;
+        writer.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
         writer.flush().map_err(|e| e.to_string())?;
     }
     Ok(())

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -13,7 +13,7 @@ import {
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
-import { attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import { Plus, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { useI18n } from "../i18n";
 import "@xterm/xterm/css/xterm.css";
@@ -134,9 +134,10 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
 
       const writer = createSmartWriter(term);
       const disposeSmartCopy = attachSmartCopy(term);
-      const disposeOnData = term.onData((data) => {
+      const linuxIME = attachLinuxIMEFix(term, (data) => {
         invoke("send_input", { taskId: shellId, data }).catch(() => {});
       });
+      const disposeOnData = { dispose: () => linuxIME.dispose() };
 
       const resizeObserver = new ResizeObserver(() => {
         setTimeout(() => {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -11,7 +11,7 @@ import {
   safeFit,
   createSmartWriter,
 } from "./terminalShared";
-import { attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -118,7 +118,8 @@ export function TerminalView({
     });
 
     const disposeSmartCopy = attachSmartCopy(term);
-    const disposeOnData = term.onData((data) => onInputRef.current(data));
+    const linuxIME = attachLinuxIMEFix(term, (data) => onInputRef.current(data));
+    const disposeOnData = { dispose: () => linuxIME.dispose() };
 
     const handlePointerDown = (e: PointerEvent) => {
       if (e.button === 0) {

--- a/src/components/new-task/PromptEditor.tsx
+++ b/src/components/new-task/PromptEditor.tsx
@@ -291,13 +291,13 @@ export function PromptEditor({
   function handleInput() {
     const editor = editorRef.current;
     if (!editor) return;
+    // Skip processing during IME composition to prevent duplicate text on Linux WebKitGTK
+    if (isComposingRef.current) return;
     const text = editor.textContent || "";
     const hasChips = !!editor.querySelector("[data-file-path]");
     onSetIsEmpty(!text.trim() && !hasChips);
     captureContent();
-    if (!isComposingRef.current) {
-      onUpdateMention();
-    }
+    onUpdateMention();
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
@@ -402,6 +402,14 @@ export function PromptEditor({
         }}
         onCompositionEnd={() => {
           isComposingRef.current = false;
+          // Capture the final composed text after IME composition completes
+          const editor = editorRef.current;
+          if (editor) {
+            const text = editor.textContent || "";
+            const hasChips = !!editor.querySelector("[data-file-path]");
+            onSetIsEmpty(!text.trim() && !hasChips);
+          }
+          captureContent();
           onUpdateMention();
         }}
         style={

--- a/src/components/terminalInputFix.ts
+++ b/src/components/terminalInputFix.ts
@@ -5,9 +5,12 @@ type TerminalWithInput = Pick<Terminal, "input" | "textarea">;
 
 function isMacWebKit(): boolean {
   if (APP_PLATFORM !== "macos" || typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent;
-  const isWebKit = ua.includes("AppleWebKit");
-  return isWebKit;
+  return navigator.userAgent.includes("AppleWebKit");
+}
+
+function isLinuxWebKit(): boolean {
+  if (APP_PLATFORM !== "other" || typeof navigator === "undefined") return false;
+  return navigator.userAgent.includes("AppleWebKit");
 }
 
 function getPrintableSymbolInput(data: string | null): string | null {
@@ -60,5 +63,93 @@ export function attachMacWebKitShiftInputFix(term: TerminalWithInput): () => voi
   return () => {
     textarea.removeEventListener("keydown", handleKeyDown);
     textarea.removeEventListener("beforeinput", handleBeforeInput);
+  };
+}
+
+export function attachLinuxIMEFix(
+  term: Terminal,
+  onDataCallback: (data: string) => void,
+): { dispose: () => void } {
+  if (!isLinuxWebKit() || !term.textarea) {
+    const disposable = term.onData(onDataCallback);
+    return { dispose: () => disposable.dispose() };
+  }
+
+  const textarea = term.textarea;
+  let isComposing = false;
+  let compositionText = "";
+
+  const sendText = (text: string | null | undefined) => {
+    if (!text) return;
+    onDataCallback(text);
+  };
+
+  const handleCompositionStartCapture = (event: CompositionEvent) => {
+    isComposing = true;
+    compositionText = "";
+    textarea.value = "";
+    event.stopImmediatePropagation();
+  };
+
+  const handleCompositionUpdateCapture = (event: CompositionEvent) => {
+    compositionText = event.data ?? "";
+    event.stopImmediatePropagation();
+  };
+
+  const handleCompositionEndCapture = (event: CompositionEvent) => {
+    const text = event.data || compositionText;
+    isComposing = false;
+    compositionText = "";
+    textarea.value = "";
+    event.stopImmediatePropagation();
+    sendText(text);
+  };
+
+  const handleBeforeInputCapture = (event: InputEvent) => {
+    if (event.inputType === "insertCompositionText") {
+      compositionText = event.data ?? compositionText;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    const symbol = getPrintableSymbolInput(event.data);
+    if (symbol !== null && isSymbolInputType(event.inputType)) {
+      textarea.value = "";
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      sendText(symbol);
+      return;
+    }
+
+    if (isComposing) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };
+
+  const handleKeyDownCapture = (event: KeyboardEvent) => {
+    if (event.keyCode === 229 || isComposing) {
+      event.stopImmediatePropagation();
+    }
+  };
+
+  const disposable = term.onData(onDataCallback);
+
+  textarea.addEventListener("compositionstart", handleCompositionStartCapture, true);
+  textarea.addEventListener("compositionupdate", handleCompositionUpdateCapture, true);
+  textarea.addEventListener("compositionend", handleCompositionEndCapture, true);
+  textarea.addEventListener("beforeinput", handleBeforeInputCapture, true);
+  textarea.addEventListener("keydown", handleKeyDownCapture, true);
+
+  return {
+    dispose: () => {
+      textarea.removeEventListener("compositionstart", handleCompositionStartCapture, true);
+      textarea.removeEventListener("compositionupdate", handleCompositionUpdateCapture, true);
+      textarea.removeEventListener("compositionend", handleCompositionEndCapture, true);
+      textarea.removeEventListener("beforeinput", handleBeforeInputCapture, true);
+      textarea.removeEventListener("keydown", handleKeyDownCapture, true);
+      disposable.dispose();
+    },
   };
 }


### PR DESCRIPTION
## Summary
- move Linux terminal IME handling to the frontend composition boundary
- keep PTY input as a raw passthrough instead of backend guesswork and dedup heuristics
- avoid duplicate composition updates in the prompt editor on Linux WebKit

## Test plan
- [x] verify Chinese IME input in the embedded task terminal on Linux
- [x] verify Chinese IME input in the shell terminal on Linux
- [x] run `pnpm build`
- [x] build desktop packages with `pnpm tauri build`