### PR TITLE
feat: support dragging files into task terminals

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, ChevronDown, RotateCcw } from "lucide-react";
 import { getFileColor } from "../utils";
 import { useToast } from "./Toast";
 import { useI18n } from "../i18n";
+import { dispatchTerminalFileDropAtPoint } from "./terminalDragDrop";
 
 interface FsEntry {
   name: string;
@@ -147,10 +148,84 @@ function TreeItem({
   const isSelected = selectedPath === node.path;
   const isContextTarget = contextPath === node.path;
   const isHighlighted = isSelected || isContextTarget;
+  const [dragPreview, setDragPreview] = useState<{ x: number; y: number } | null>(null);
+  const pointerDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    moved: boolean;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const resetDragCursor = () => {
+    document.body.style.cursor = "";
+  };
+
+  const suppressNextClick = () => {
+    suppressClickRef.current = true;
+    window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  };
+
+  useEffect(() => resetDragCursor, []);
+
   return (
     <div
-      onClick={() => (node.is_dir ? onToggle(node.path) : onSelect(node))}
+      onClick={(e) => {
+        if (suppressClickRef.current) {
+          suppressClickRef.current = false;
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+        node.is_dir ? onToggle(node.path) : onSelect(node);
+      }}
       onContextMenu={(e) => onContextMenu(e, node)}
+      onPointerDown={(e) => {
+        if (node.is_dir || e.button !== 0) return;
+        setDragPreview(null);
+        pointerDragRef.current = {
+          pointerId: e.pointerId,
+          startX: e.clientX,
+          startY: e.clientY,
+          moved: false,
+        };
+        e.currentTarget.setPointerCapture(e.pointerId);
+      }}
+      onPointerMove={(e) => {
+        const drag = pointerDragRef.current;
+        if (!drag || drag.pointerId !== e.pointerId) return;
+        if (Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) >= 4) {
+          drag.moved = true;
+          document.body.style.cursor = "pointer";
+          setDragPreview({ x: e.clientX, y: e.clientY });
+        }
+      }}
+      onPointerUp={(e) => {
+        const drag = pointerDragRef.current;
+        pointerDragRef.current = null;
+        setDragPreview(null);
+        resetDragCursor();
+        if (!drag || drag.pointerId !== e.pointerId) return;
+        if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+          e.currentTarget.releasePointerCapture(e.pointerId);
+        }
+        if (!drag.moved) return;
+        suppressNextClick();
+        if (dispatchTerminalFileDropAtPoint(node.path, e.clientX, e.clientY)) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }}
+      onPointerCancel={(e) => {
+        pointerDragRef.current = null;
+        setDragPreview(null);
+        resetDragCursor();
+        if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+          e.currentTarget.releasePointerCapture(e.pointerId);
+        }
+      }}
       style={{
         display: "flex",
         alignItems: "center",
@@ -158,7 +233,7 @@ function TreeItem({
         height: ROW_HEIGHT,
         paddingLeft: 8 + depth * 14,
         paddingRight: 8,
-        cursor: "pointer",
+        cursor: dragPreview ? "pointer" : "default",
         borderRadius: 4,
         margin: "0 4px",
         boxSizing: "border-box",
@@ -207,6 +282,53 @@ function TreeItem({
       >
         {node.name}
       </span>
+      {dragPreview && (
+        <>
+          <div
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 3999,
+              cursor: "pointer",
+              background: "transparent",
+            }}
+          />
+          <div
+            style={{
+              position: "fixed",
+              left: dragPreview.x,
+              top: dragPreview.y,
+              transform: "translate(-50%, -50%)",
+              zIndex: 4000,
+              maxWidth: 280,
+              height: 26,
+              padding: "0 10px",
+              borderRadius: 6,
+              border: "1px solid #d1d5db",
+              background: "#ffffff",
+              color: "#111827",
+              boxShadow: "0 10px 24px color-mix(in srgb, #000 22%, transparent)",
+              display: "flex",
+              alignItems: "center",
+              gap: 7,
+              pointerEvents: "none",
+              fontFamily: "var(--font-ui)",
+              fontSize: 12,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
+            <FileIcon
+              name={node.name}
+              ext={node.extension}
+              isDir={node.is_dir}
+              expanded={node.expanded}
+              isGitignored={node.is_gitignored}
+            />
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{node.name}</span>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -12,6 +12,10 @@ import {
   createSmartWriter,
 } from "./terminalShared";
 import { attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import {
+  formatDroppedPathsForTerminal,
+  registerTerminalFileDropTarget,
+} from "./terminalDragDrop";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -47,9 +51,11 @@ export function TerminalView({
   const onRegisterRef = useRef(onRegisterTerminal);
   const onReadyRef = useRef(onReady);
   const onSnapshotRef = useRef(onSnapshot);
+  const isActiveRef = useRef(isActive);
   const lastSizeRef = useRef<{ cols: number; rows: number } | null>(null);
   onReadyRef.current = onReady;
   onSnapshotRef.current = onSnapshot;
+  isActiveRef.current = isActive;
 
   // Keep refs current on every render
   onInputRef.current = onInput;
@@ -89,6 +95,14 @@ export function TerminalView({
     };
 
     const writer = createSmartWriter(term);
+    const unregisterDropTarget = registerTerminalFileDropTarget(
+      container,
+      (paths) => {
+        onInputRef.current(formatDroppedPathsForTerminal(paths));
+        focusTerminal();
+      },
+      () => isActiveRef.current,
+    );
 
     const terminalGeneration = onRegisterRef.current(writer.write);
 
@@ -164,6 +178,7 @@ export function TerminalView({
         /* ignore */
       }
       onRegisterRef.current(null);
+      unregisterDropTarget();
       fitAddonRef.current = null;
       disposeInputFix();
       disposeSmartCopy();

--- a/src/components/terminalDragDrop.ts
+++ b/src/components/terminalDragDrop.ts
@@ -1,0 +1,51 @@
+const terminalDropTargets: Array<{
+  element: HTMLElement;
+  onDropPaths: (paths: string[]) => void;
+  isEnabled?: () => boolean;
+}> = [];
+
+export function isPointInsideElement(
+  event: { clientX: number; clientY: number },
+  element: Element,
+): boolean {
+  const rect = element.getBoundingClientRect();
+  return (
+    event.clientX >= rect.left &&
+    event.clientX <= rect.right &&
+    event.clientY >= rect.top &&
+    event.clientY <= rect.bottom
+  );
+}
+
+export function registerTerminalFileDropTarget(
+  element: HTMLElement,
+  onDropPaths: (paths: string[]) => void,
+  isEnabled?: () => boolean,
+): () => void {
+  const target = { element, onDropPaths, isEnabled };
+  terminalDropTargets.push(target);
+  return () => {
+    const index = terminalDropTargets.indexOf(target);
+    if (index !== -1) terminalDropTargets.splice(index, 1);
+  };
+}
+
+export function dispatchTerminalFileDropAtPoint(path: string, clientX: number, clientY: number): boolean {
+  for (let i = terminalDropTargets.length - 1; i >= 0; i--) {
+    const target = terminalDropTargets[i];
+    if (target.isEnabled && !target.isEnabled()) continue;
+    if (!document.contains(target.element)) continue;
+    if (!isPointInsideElement({ clientX, clientY }, target.element)) continue;
+    target.onDropPaths([path]);
+    return true;
+  }
+  return false;
+}
+
+export function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function formatDroppedPathsForTerminal(paths: string[]): string {
+  return paths.map(quoteShellArg).join(" ");
+}

--- a/src/test/terminalDragDrop.test.ts
+++ b/src/test/terminalDragDrop.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  dispatchTerminalFileDropAtPoint,
+  formatDroppedPathsForTerminal,
+  isPointInsideElement,
+  quoteShellArg,
+  registerTerminalFileDropTarget,
+} from "../components/terminalDragDrop";
+
+describe("quoteShellArg", () => {
+  it("wraps paths so spaces remain a single shell argument", () => {
+    expect(quoteShellArg("/Users/me/My Project/file.txt")).toBe("'/Users/me/My Project/file.txt'");
+  });
+
+  it("escapes single quotes inside paths", () => {
+    expect(quoteShellArg("/tmp/it's.txt")).toBe("'/tmp/it'\\''s.txt'");
+  });
+});
+
+describe("formatDroppedPathsForTerminal", () => {
+  it("joins multiple quoted paths with spaces", () => {
+    expect(formatDroppedPathsForTerminal(["/tmp/a.txt", "/tmp/b b.txt"])).toBe(
+      "'/tmp/a.txt' '/tmp/b b.txt'",
+    );
+  });
+});
+
+describe("isPointInsideElement", () => {
+  it("checks drag coordinates against the element bounds", () => {
+    const element = document.createElement("div");
+    element.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        right: 110,
+        bottom: 120,
+        width: 100,
+        height: 100,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    expect(isPointInsideElement({ clientX: 50, clientY: 50 }, element)).toBe(true);
+    expect(isPointInsideElement({ clientX: 5, clientY: 50 }, element)).toBe(false);
+  });
+});
+
+describe("terminal file drop target registry", () => {
+  it("dispatches a path to the registered target at the pointer position", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    element.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        right: 110,
+        bottom: 120,
+        width: 100,
+        height: 100,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const received: string[][] = [];
+    const unregister = registerTerminalFileDropTarget(element, (paths) => received.push(paths));
+
+    expect(dispatchTerminalFileDropAtPoint("/tmp/a.txt", 50, 50)).toBe(true);
+    expect(received).toEqual([["/tmp/a.txt"]]);
+
+    unregister();
+    document.body.removeChild(element);
+  });
+
+  it("skips disabled targets", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    element.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        right: 110,
+        bottom: 120,
+        width: 100,
+        height: 100,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const received: string[][] = [];
+    const unregister = registerTerminalFileDropTarget(
+      element,
+      (paths) => received.push(paths),
+      () => false,
+    );
+
+    expect(dispatchTerminalFileDropAtPoint("/tmp/a.txt", 50, 50)).toBe(false);
+    expect(received).toEqual([]);
+
+    unregister();
+    document.body.removeChild(element);
+  });
+
+  it("falls through a disabled top target to an enabled target underneath", () => {
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    document.body.append(first, second);
+    const rect = {
+      left: 10,
+      top: 20,
+      right: 110,
+      bottom: 120,
+      width: 100,
+      height: 100,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    } as DOMRect;
+    first.getBoundingClientRect = () => rect;
+    second.getBoundingClientRect = () => rect;
+
+    const received: string[][] = [];
+    const unregisterFirst = registerTerminalFileDropTarget(first, (paths) => received.push(paths));
+    const unregisterSecond = registerTerminalFileDropTarget(
+      second,
+      () => received.push(["disabled"]),
+      () => false,
+    );
+
+    expect(dispatchTerminalFileDropAtPoint("/tmp/a.txt", 50, 50)).toBe(true);
+    expect(received).toEqual([["/tmp/a.txt"]]);
+
+    unregisterSecond();
+    unregisterFirst();
+    first.remove();
+    second.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Add FILE panel pointer-drag support for inserting quoted paths into visible task terminals
- Register task terminals as drop targets only while active to avoid hidden terminals receiving paths
- Add helper tests for shell quoting and drop target dispatch behavior

## Test Plan
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm test