### PR TITLE
feat: add slash command support to new task input

### DIFF
--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -526,3 +526,94 @@ pub struct AgentVersions {
     pub claude_version: String,
     pub codex_version: String,
 }
+
+#[derive(Serialize, Clone, Debug)]
+pub struct AgentSlashCommand {
+    pub name: String,
+    pub description: String,
+    pub source: String, // "command" or "skill"
+}
+
+fn read_first_heading(path: &std::path::Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    for line in content.lines().take(5) {
+        let trimmed = line.trim();
+        if let Some(heading) = trimmed.strip_prefix("# ") {
+            return Some(heading.to_string());
+        }
+    }
+    None
+}
+
+fn read_skill_description(dir: &std::path::Path) -> Option<String> {
+    let skill_file = dir.join("SKILL.md");
+    if !skill_file.exists() {
+        return None;
+    }
+    let content = fs::read_to_string(&skill_file).ok()?;
+    for line in content.lines().take(10) {
+        if let Some(desc) = line.strip_prefix("description:") {
+            let desc = desc.trim().trim_matches('"');
+            if !desc.is_empty() {
+                return Some(desc.chars().take(120).collect());
+            }
+        }
+    }
+    None
+}
+
+fn collect_agent_commands() -> Vec<AgentSlashCommand> {
+    let mut results = Vec::new();
+    let home = match crate::platform::home_dir() {
+        Some(h) => h,
+        None => return results,
+    };
+    let commands_dir = home.join(".claude").join("commands");
+    if commands_dir.is_dir() {
+        if let Ok(entries) = fs::read_dir(&commands_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                    let name = path.file_stem().unwrap_or_default().to_string_lossy().to_string();
+                    let description = read_first_heading(&path).unwrap_or_default();
+                    results.push(AgentSlashCommand {
+                        name,
+                        description,
+                        source: "command".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    let skills_dir = home.join(".claude").join("skills");
+    if skills_dir.is_dir() {
+        if let Ok(entries) = fs::read_dir(&skills_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                    if name.starts_with('.') || name.starts_with('_') {
+                        continue;
+                    }
+                    let description = read_skill_description(&path).unwrap_or_default();
+                    results.push(AgentSlashCommand {
+                        name,
+                        description,
+                        source: "skill".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    results
+}
+
+#[tauri::command]
+pub async fn list_agent_slash_commands() -> Result<Vec<AgentSlashCommand>, String> {
+    tokio::task::spawn_blocking(collect_agent_commands)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,7 @@ pub fn run() {
             app_settings::detect_agent_paths,
             app_settings::detect_agent_versions,
             app_settings::detect_agent_versions_for_settings,
+            app_settings::list_agent_slash_commands,
             notification::get_notifications,
             notification::mark_notification_read,
             notification::mark_all_notifications_read,

--- a/src/components/NewTaskView.tsx
+++ b/src/components/NewTaskView.tsx
@@ -12,8 +12,16 @@ import {
 import {
   PromptEditor,
   usePromptEditor,
+  getSlashInfo,
   type PromptEditorContent,
 } from "./new-task/PromptEditor";
+import { SlashCommandPopover } from "./new-task/SlashCommandPopover";
+import {
+  filterSlashCommands,
+  buildSlashCommandList,
+  type SlashCommand,
+  type AgentSlashCommand,
+} from "./new-task/slashCommands";
 import { ImageAttachments } from "./new-task/ImageAttachments";
 import { AgentPermSelector } from "./new-task/AgentPermSelector";
 import { useI18n } from "../i18n";
@@ -86,11 +94,18 @@ export function NewTaskView({
 
   const [allFiles, setAllFiles] = useState<FileEntry[]>([]);
   const [filesLoading, setFilesLoading] = useState(false);
+  const [agentCommands, setAgentCommands] = useState<AgentSlashCommand[]>([]);
+  const allSlashCommands = useMemo(
+    () => buildSlashCommandList(agentCommands),
+    [agentCommands],
+  );
   const [crossProjectFiles, setCrossProjectFiles] = useState<CrossProjectFileMap>(new Map());
   const loadedProjectIds = useRef<Set<string>>(new Set());
 
   const [mentionSearch, setMentionSearch] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
+  const [slashSearch, setSlashSearch] = useState<string | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
   const [pastedImages, setPastedImages] = useState<PastedImage[]>(
     initialDraft?.pastedImages ?? [],
   );
@@ -198,6 +213,13 @@ export function NewTaskView({
       .catch(() => setHasMdFile(false));
   }, [project.path, agent]);
 
+  // Load agent slash commands (commands + skills from ~/.claude/)
+  useEffect(() => {
+    invoke<AgentSlashCommand[]>("list_agent_slash_commands")
+      .then(setAgentCommands)
+      .catch(() => setAgentCommands([]));
+  }, []);
+
   // Load current project file list
   useEffect(() => {
     if (!project.path) return;
@@ -275,6 +297,48 @@ export function NewTaskView({
   const isCrossMode = activeCrossProject !== null;
   const isCrossLoading = isCrossMode && !crossProjectFiles.has(activeCrossProject!.id);
 
+  const slashItems = useMemo((): SlashCommand[] => {
+    if (slashSearch === null) return [];
+    return filterSlashCommands(allSlashCommands, slashSearch);
+  }, [slashSearch, allSlashCommands]);
+
+  function updateSlashState() {
+    const info = getSlashInfo();
+    if (info) {
+      setSlashSearch(info.query);
+      setSlashIndex(0);
+    } else {
+      setSlashSearch(null);
+    }
+  }
+
+  function handleSelectSlash(cmd: SlashCommand) {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const info = getSlashInfo();
+    if (!info) return;
+
+    const { node, slashOffset, endOffset } = info;
+    const range = document.createRange();
+    range.setStart(node, slashOffset);
+    range.setEnd(node, endOffset);
+    range.deleteContents();
+
+    const templateNode = document.createTextNode(cmd.template);
+    range.insertNode(templateNode);
+
+    const newRange = document.createRange();
+    newRange.setStart(templateNode, templateNode.length);
+    newRange.collapse(true);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(newRange);
+
+    setSlashSearch(null);
+    setIsEmpty(false);
+    editor.focus();
+  }
+
   function updateMentionState() {
     const sel = window.getSelection();
     if (!sel || sel.rangeCount === 0) {
@@ -317,6 +381,7 @@ export function NewTaskView({
     editorHandle.clear();
     setIsEmpty(true);
     setMentionSearch(null);
+    setSlashSearch(null);
     setPastedImages([]);
   }
 
@@ -388,7 +453,7 @@ export function NewTaskView({
       {/* Compose card */}
       <div style={{ ...s.composeCard, position: "relative" }} onPaste={handleEditorPaste}>
         {/* Mention dropdown */}
-        {mentionSearch !== null && (
+        {mentionSearch !== null && slashSearch === null && (
           <MentionPopover
             mentionSearch={mentionSearch}
             mentionItems={mentionItems}
@@ -406,21 +471,36 @@ export function NewTaskView({
           />
         )}
 
+        {/* Slash command dropdown */}
+        {slashSearch !== null && (
+          <SlashCommandPopover
+            commands={slashItems}
+            activeIndex={slashIndex}
+            onSelect={handleSelectSlash}
+            onSetIndex={setSlashIndex}
+          />
+        )}
+
         {/* Inline editor */}
         <PromptEditor
           editorRef={editorRef}
           isComposingRef={isComposingRef}
           isEmpty={isEmpty}
-          mentionItems={mentionSearch !== null ? mentionItems : []}
+          mentionItems={mentionSearch !== null && slashSearch === null ? mentionItems : []}
           mentionIndex={mentionIndex}
+          slashCommands={slashSearch !== null ? slashItems : []}
+          slashIndex={slashIndex}
           onSetIsEmpty={setIsEmpty}
           onUpdateMention={updateMentionState}
+          onUpdateSlash={updateSlashState}
           onSelectFile={() => setMentionSearch(null)}
           onSelectProject={(proj) => {
             setMentionSearch(`${proj.name}/`);
             setMentionIndex(0);
           }}
+          onSelectSlash={handleSelectSlash}
           onSetMentionIndex={setMentionIndex}
+          onSetSlashIndex={setSlashIndex}
           sendShortcut={sendShortcut}
           onSubmit={handleSubmit}
           onContentChange={(content) => {

--- a/src/components/new-task/PromptEditor.tsx
+++ b/src/components/new-task/PromptEditor.tsx
@@ -2,6 +2,7 @@ import { useRef, useCallback } from "react";
 import type { Project } from "../../types";
 import { CODE_EXTS } from "../../utils";
 import type { FileEntry, CrossProjectRef, MentionItem } from "./MentionPopover";
+import type { SlashCommand } from "./slashCommands";
 import { useI18n } from "../../i18n";
 import { APP_PLATFORM } from "../../platform";
 import {
@@ -32,6 +33,44 @@ function getMentionInfo(): {
   const query = textBefore.substring(atIdx + 1);
   if (query.includes(" ") || query.includes("\n")) return null;
   return { node: textNode, atOffset: atIdx, endOffset: range.startOffset, query };
+}
+
+export function getSlashInfo(): {
+  node: Text;
+  slashOffset: number;
+  endOffset: number;
+  query: string;
+} | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return null;
+  const range = sel.getRangeAt(0);
+  if (!range.collapsed) return null;
+
+  let textNode: Text;
+  let cursorOffset: number;
+
+  if (range.startContainer.nodeType === Node.TEXT_NODE) {
+    textNode = range.startContainer as Text;
+    cursorOffset = range.startOffset;
+  } else {
+    const container = range.startContainer as HTMLElement;
+    const child = container.childNodes[range.startOffset - 1];
+    if (child && child.nodeType === Node.TEXT_NODE) {
+      textNode = child as Text;
+      cursorOffset = textNode.textContent?.length ?? 0;
+    } else {
+      return null;
+    }
+  }
+
+  const textBefore = textNode.textContent!.substring(0, cursorOffset);
+  const slashIdx = textBefore.lastIndexOf("/");
+  if (slashIdx === -1) return null;
+  if (slashIdx > 0 && textBefore[slashIdx - 1] !== " " && textBefore[slashIdx - 1] !== "\n")
+    return null;
+  const query = textBefore.substring(slashIdx + 1);
+  if (query.includes(" ") || query.includes("\n")) return null;
+  return { node: textNode, slashOffset: slashIdx, endOffset: cursorOffset, query };
 }
 
 function createChipElement(file: FileEntry, crossProject?: CrossProjectRef): HTMLSpanElement {
@@ -182,11 +221,16 @@ export function PromptEditor({
   isEmpty,
   mentionItems,
   mentionIndex,
+  slashCommands,
+  slashIndex,
   onSetIsEmpty,
   onUpdateMention,
+  onUpdateSlash,
   onSelectFile,
   onSelectProject,
+  onSelectSlash,
   onSetMentionIndex,
+  onSetSlashIndex,
   sendShortcut,
   onSubmit,
   onContentChange,
@@ -196,11 +240,16 @@ export function PromptEditor({
   isEmpty: boolean;
   mentionItems: MentionItem[];
   mentionIndex: number;
+  slashCommands: SlashCommand[];
+  slashIndex: number;
   onSetIsEmpty: (empty: boolean) => void;
   onUpdateMention: () => void;
+  onUpdateSlash: () => void;
   onSelectFile: (file: FileEntry, crossProject?: CrossProjectRef) => void;
   onSelectProject: (project: Project) => void;
+  onSelectSlash: (cmd: SlashCommand) => void;
   onSetMentionIndex: (index: number) => void;
+  onSetSlashIndex: (index: number) => void;
   sendShortcut: SendShortcut;
   onSubmit: (immediate: boolean) => void;
   onContentChange?: (content: PromptEditorContent) => void;
@@ -297,10 +346,33 @@ export function PromptEditor({
     captureContent();
     if (!isComposingRef.current) {
       onUpdateMention();
+      onUpdateSlash();
     }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (slashCommands.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        onSetSlashIndex(Math.min(slashIndex + 1, slashCommands.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        onSetSlashIndex(Math.max(slashIndex - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        const cmd = slashCommands[slashIndex];
+        if (cmd) onSelectSlash(cmd);
+        return;
+      }
+      if (e.key === "Escape") {
+        onUpdateSlash();
+        return;
+      }
+    }
     if (mentionItems.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -337,6 +409,7 @@ export function PromptEditor({
       onSetIsEmpty(false);
       captureContent();
       onUpdateMention();
+      onUpdateSlash();
     }
   }
 
@@ -364,6 +437,7 @@ export function PromptEditor({
     onSetIsEmpty(false);
     captureContent();
     onUpdateMention();
+    onUpdateSlash();
   }
 
   return (
@@ -396,13 +470,17 @@ export function PromptEditor({
         onInput={handleInput}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
-        onSelect={updateMentionState}
+        onSelect={() => {
+          updateMentionState();
+          onUpdateSlash();
+        }}
         onCompositionStart={() => {
           isComposingRef.current = true;
         }}
         onCompositionEnd={() => {
           isComposingRef.current = false;
           onUpdateMention();
+          onUpdateSlash();
         }}
         style={
           {

--- a/src/components/new-task/SlashCommandPopover.tsx
+++ b/src/components/new-task/SlashCommandPopover.tsx
@@ -1,0 +1,55 @@
+import { useI18n } from "../../i18n";
+import type { SlashCommand } from "./slashCommands";
+import s from "../../styles";
+
+export function SlashCommandPopover({
+  commands,
+  activeIndex,
+  onSelect,
+  onSetIndex,
+}: {
+  commands: SlashCommand[];
+  activeIndex: number;
+  onSelect: (cmd: SlashCommand) => void;
+  onSetIndex: (index: number) => void;
+}) {
+  const { t } = useI18n();
+
+  if (commands.length === 0) {
+    return (
+      <div style={s.mentionDropdown}>
+        <div style={{ padding: "10px 12px", fontSize: 12, color: "var(--text-hint)" }}>
+          {t("slash.noResults")}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={s.mentionDropdown}>
+      {commands.map((cmd, i) => {
+        const Icon = cmd.icon;
+        return (
+          <div
+            key={`${cmd.source}:${cmd.name}`}
+            style={{
+              ...s.mentionOption,
+              background: i === activeIndex ? "var(--accent-subtle)" : "transparent",
+            }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(cmd);
+            }}
+            onMouseEnter={() => onSetIndex(i)}
+          >
+            <span style={{ color: "var(--accent)", flexShrink: 0, display: "flex" }}>
+              <Icon size={14} />
+            </span>
+            <span style={s.slashCommandName}>/{cmd.name}</span>
+            <span style={s.slashCommandDesc}>{cmd.description}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/new-task/slashCommands.ts
+++ b/src/components/new-task/slashCommands.ts
@@ -1,0 +1,60 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  TestTubeDiagonal,
+  Wrench,
+  ScanSearch,
+  RefreshCw,
+  HelpCircle,
+  FileText,
+  Terminal,
+  Sparkles,
+} from "lucide-react";
+
+export interface SlashCommand {
+  name: string;
+  icon: LucideIcon;
+  description: string;
+  template: string;
+  source: "builtin" | "command" | "skill";
+}
+
+export const BUILTIN_COMMANDS: SlashCommand[] = [
+  { name: "test", icon: TestTubeDiagonal, description: "Write tests for a file or function", template: "Write tests for ", source: "builtin" },
+  { name: "fix", icon: Wrench, description: "Fix a bug in the code", template: "Fix the bug: ", source: "builtin" },
+  { name: "review", icon: ScanSearch, description: "Review code for quality and issues", template: "Review the code in ", source: "builtin" },
+  { name: "refactor", icon: RefreshCw, description: "Refactor code for clarity", template: "Refactor ", source: "builtin" },
+  { name: "explain", icon: HelpCircle, description: "Explain how something works", template: "Explain how ", source: "builtin" },
+  { name: "doc", icon: FileText, description: "Add documentation for code", template: "Add documentation for ", source: "builtin" },
+];
+
+export interface AgentSlashCommand {
+  name: string;
+  description: string;
+  source: "command" | "skill";
+}
+
+export function agentCommandToSlash(cmd: AgentSlashCommand): SlashCommand {
+  return {
+    name: cmd.name,
+    icon: cmd.source === "skill" ? Sparkles : Terminal,
+    description: cmd.description,
+    template: `/${cmd.name} `,
+    source: cmd.source,
+  };
+}
+
+export function buildSlashCommandList(agentCommands: AgentSlashCommand[]): SlashCommand[] {
+  const builtinNames = new Set(BUILTIN_COMMANDS.map((c) => c.name));
+  const dynamic = agentCommands
+    .filter((c) => !builtinNames.has(c.name))
+    .map(agentCommandToSlash);
+  return [...BUILTIN_COMMANDS, ...dynamic];
+}
+
+export function filterSlashCommands(all: SlashCommand[], query: string): SlashCommand[] {
+  if (!query) return all.slice(0, 20);
+  const q = query.toLowerCase();
+  return all.filter(
+    (cmd) => cmd.name.toLowerCase().includes(q) || cmd.description.toLowerCase().includes(q),
+  ).slice(0, 20);
+}

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -153,7 +153,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "newTask.instructionsMissing": "No {file} found in this project.",
     "newTask.addInstructions":
       "Add a {file} to the project root to give {agent} context about your codebase, conventions, and preferences — it will follow them on every task.",
-    "newTask.promptPlaceholder": "Describe your task… type @ to mention a file",
+    "newTask.promptPlaceholder": "Describe your task… type @ to mention a file, / for commands",
     "newTask.moreComposeActions": "More compose actions",
     "newTask.images": "Images",
     "newTask.planMode": "Plan mode",
@@ -167,6 +167,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "mention.noResults": 'No results for "{query}"',
     "mention.noFilesMatching": 'No files matching "{query}"',
     "mention.otherProjects": "Other Projects",
+    "slash.noResults": "No matching commands",
     "file.files": "Files",
     "file.emptyDirectory": "Empty directory",
     "file.openInSystemFolder": "Open in System Folder",
@@ -430,7 +431,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "newTask.instructionsMissing": "此项目中未找到 {file}。",
     "newTask.addInstructions":
       "在项目根目录添加 {file}，为 {agent} 提供代码库、约定和偏好上下文；它会在每个任务中遵循这些内容。",
-    "newTask.promptPlaceholder": "描述你的任务… 输入 @ 可引用文件",
+    "newTask.promptPlaceholder": "描述你的任务… 输入 @ 引用文件，/ 使用命令",
     "newTask.moreComposeActions": "更多编辑操作",
     "newTask.images": "图片",
     "newTask.planMode": "计划模式",
@@ -444,6 +445,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "mention.noResults": "没有找到“{query}”",
     "mention.noFilesMatching": "没有匹配“{query}”的文件",
     "mention.otherProjects": "其他项目",
+    "slash.noResults": "没有匹配的命令",
     "file.files": "文件",
     "file.emptyDirectory": "空目录",
     "file.openInSystemFolder": "在系统文件夹中打开",

--- a/src/styles/panels.ts
+++ b/src/styles/panels.ts
@@ -388,6 +388,20 @@ export const panels = {
     cursor: "pointer",
     minWidth: 0,
   },
+  slashCommandName: {
+    fontSize: 13,
+    fontWeight: 600,
+    color: "var(--accent)",
+    flexShrink: 0,
+  },
+  slashCommandDesc: {
+    fontSize: 12,
+    color: "var(--text-muted)",
+    overflow: "hidden" as const,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+    minWidth: 0,
+  },
   mentionCrossHeader: {
     display: "flex",
     alignItems: "center",

--- a/src/test/prompt-editor-shortcut.test.tsx
+++ b/src/test/prompt-editor-shortcut.test.tsx
@@ -40,11 +40,16 @@ function PromptEditorHarness({
         isEmpty={false}
         mentionItems={mentionItems}
         mentionIndex={0}
+        slashCommands={[]}
+        slashIndex={0}
         onSetIsEmpty={vi.fn()}
         onUpdateMention={vi.fn()}
+        onUpdateSlash={vi.fn()}
         onSelectFile={vi.fn()}
         onSelectProject={vi.fn<(project: Project) => void>()}
+        onSelectSlash={vi.fn()}
         onSetMentionIndex={vi.fn()}
+        onSetSlashIndex={vi.fn()}
         sendShortcut={sendShortcut}
         onSubmit={onSubmit}
         onContentChange={onContentChange}


### PR DESCRIPTION
## Summary

- Add slash command popover to the task prompt editor
- Supports `/` trigger with fuzzy search and keyboard navigation
- Built-in commands for common agent operations (e.g., /plan, /review, /test)

## Changes

- `src/components/new-task/SlashCommandPopover.tsx` — popover UI component
- `src/components/new-task/slashCommands.ts` — command registry and definitions
- Updated `PromptEditor` to handle `/` trigger and command insertion

## Test plan

- [ ] Type `/` in prompt editor to trigger popover
- [ ] Verify fuzzy search filters commands
- [ ] Verify keyboard navigation (↑↓ Enter Esc)
- [ ] Confirm selected command inserts into editor