### PR TITLE
fix: prevent completed task status from being overwritten by late events

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub struct TaskManager {
     pub(crate) child_handles:
         Mutex<HashMap<String, Arc<std::sync::Mutex<Box<dyn portable_pty::Child + Send + Sync>>>>>,
     pub(crate) cancelled_tasks: Mutex<HashSet<String>>,
+    pub(crate) finalized_tasks: Mutex<HashSet<String>>,
     pub(crate) codex_sessions: Mutex<HashMap<String, CodexSessionInfo>>,
     pub(crate) claude_sessions: Mutex<HashMap<String, ClaudeSessionInfo>>,
     pub(crate) claimed_session_paths: Mutex<HashSet<String>>,
@@ -61,6 +62,7 @@ pub fn run() {
             pty_writers: Mutex::new(HashMap::new()),
             child_handles: Mutex::new(HashMap::new()),
             cancelled_tasks: Mutex::new(HashSet::new()),
+            finalized_tasks: Mutex::new(HashSet::new()),
             codex_sessions: Mutex::new(HashMap::new()),
             claude_sessions: Mutex::new(HashMap::new()),
             claimed_session_paths: Mutex::new(HashSet::new()),

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -87,6 +87,11 @@ fn finalize_task_exit(
         return;
     }
 
+    {
+        let tm = app.state::<TaskManager>();
+        tm.finalized_tasks.lock().insert(task_id.to_string());
+    }
+
     let status = if exit_ok || had_agent_session { "done" } else { "failed" };
     let payload = if status == "failed" {
         let reason = match exit_code {
@@ -517,6 +522,10 @@ pub async fn cancel_task(
 ) -> Result<(), String> {
     task_manager
         .cancelled_tasks
+        .lock()
+        .insert(task_id.clone());
+    task_manager
+        .finalized_tasks
         .lock()
         .insert(task_id.clone());
 

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -31,6 +31,10 @@ pub(crate) fn emit_task_status(app: &AppHandle, task_id: &str, status: &str) {
 }
 
 fn emit_active_task_status(app: &AppHandle, task_id: &str, status: &str) {
+    let tm = app.state::<TaskManager>();
+    if tm.finalized_tasks.lock().contains(task_id) {
+        return;
+    }
     if is_task_active(app, task_id) {
         emit_task_status(app, task_id, status);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -479,6 +479,8 @@ function App() {
       const next = prev.map((task) => {
         if (task.id !== taskId) return task;
 
+        if (!isActiveTaskStatus(task.status) && isActiveTaskStatus(status)) return task;
+
         const attentionRequestedAt =
           status === "input_required" ? (extra?.attentionRequestedAt ?? Date.now()) : undefined;
 


### PR DESCRIPTION
## Summary

- Fix a race condition where late-arriving `task-status` events could overwrite a task's `done`/`failed` status back to `running`
- Add guard checks in both frontend event handler and backend session watcher

## Changes

- `src/App.tsx` — add status guard in `task-status` event listener
- `src-tauri/src/session.rs` — skip status emission for already-completed tasks

## Test plan

- [ ] Start a task, let it complete, verify status stays `done`
- [ ] Verify no regression: normal task lifecycle (pending → running → done) still works
- [ ] Test with rapid task start/stop to trigger race condition