### PR TITLE
feat: 任务列表显示智能体类型图标

### DIFF
--- a/src/components/task-panel/TaskListItem.tsx
+++ b/src/components/task-panel/TaskListItem.tsx
@@ -4,6 +4,8 @@ import type { Task } from "../../types";
 import { StatusIcon } from "../StatusIcon";
 import { useI18n } from "../../i18n";
 import s from "../../styles";
+import claudeLogo from "../../assets/claude.svg";
+import chatgptLogo from "../../assets/chatgpt.svg";
 
 function statusLabelKey(status: Task["status"]): string {
   switch (status) {
@@ -47,6 +49,7 @@ export const TaskListItem = memo(
       <div
         style={{
           ...s.taskCard,
+          position: "relative",
           background: selected ? "var(--bg-selected)" : hov ? "var(--bg-hover)" : "transparent",
         }}
         onMouseEnter={() => setHov(true)}
@@ -63,6 +66,21 @@ export const TaskListItem = memo(
           </div>
           <div style={s.taskCardSub}>{t(statusLabelKey(task.status))}</div>
         </div>
+        <img
+          src={task.agent === "claude" ? claudeLogo : chatgptLogo}
+          title={task.agent === "claude" ? "Claude Code" : "Codex"}
+          style={{
+            ...s.agentBadge,
+            position: "absolute",
+            right: 16,
+            top: 11,
+            opacity: hov ? 0 : 1,
+            filter: task.agent === "codex" ? "var(--agent-badge-filter)" : "none",
+            pointerEvents: "none",
+            transition: "opacity 0.12s ease",
+            zIndex: 1,
+          }}
+        />
         <button
           type="button"
           aria-label={task.starred ? t("task.unstar") : t("task.star")}

--- a/src/styles/task.ts
+++ b/src/styles/task.ts
@@ -280,6 +280,14 @@ export const task = {
     whiteSpace: "nowrap",
   },
   taskCardSub: { fontSize: 11, color: "var(--text-muted)", marginTop: 1 },
+  agentBadge: {
+    flexShrink: 0,
+    width: 14,
+    height: 14,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
   taskDeleteBtn: {
     flexShrink: 0,
     width: 22,

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -127,6 +127,7 @@
   --shadow-switch-thumb: 0 1px 2px rgba(0, 0, 0, 0.18);
   --shadow-toast: 0 4px 16px rgba(0, 0, 0, 0.24), 0 1px 4px rgba(0, 0, 0, 0.14);
   --shadow-media: 0 16px 40px rgba(0, 0, 0, 0.25);
+  --agent-badge-filter: none;
 
   --radius-sm: 6px;
   --radius-md: 8px;
@@ -236,4 +237,5 @@ html.dark {
   --shadow-switch-thumb: 0 1px 2px rgba(0, 0, 0, 0.45);
   --shadow-toast: 0 4px 16px rgba(0, 0, 0, 0.55), 0 1px 4px rgba(0, 0, 0, 0.35);
   --shadow-media: 0 16px 40px rgba(0, 0, 0, 0.6);
+  --agent-badge-filter: brightness(0) invert(1) opacity(0.7);
 }


### PR DESCRIPTION
## 概述
- 在任务列表项中显示 Claude/Codex 图标，复用已有 SVG 资源（`claude.svg` / `chatgpt.svg`）
- 图标绝对定位于操作按钮区域上方，默认可见，悬浮时淡出让位给收藏/删除按钮
- 不占用额外布局空间，标题区域不受影响

Ref #69 (part 2)

## 测试计划
- [ ] 打开包含不同智能体任务的项目
- [ ] 确认 Claude 任务显示 Claude 图标，Codex 任务显示 Codex 图标
- [ ] 确认悬浮时图标消失，操作按钮出现
- [ ] 确认标题旁无多余空隙
- [ ] 确认已收藏任务悬浮时仍显示收藏标识