### PR TITLE
feat: support drag reordering in project rail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { open as openDialog, confirm } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -67,6 +67,19 @@ function persistProjectTasks(
   });
 }
 
+function reorderProjects(projects: Project[], draggedProjectId: string, targetProjectId: string) {
+  if (draggedProjectId === targetProjectId) return projects;
+
+  const sourceIndex = projects.findIndex((project) => project.id === draggedProjectId);
+  const targetIndex = projects.findIndex((project) => project.id === targetProjectId);
+  if (sourceIndex === -1 || targetIndex === -1) return projects;
+
+  const next = [...projects];
+  const [draggedProject] = next.splice(sourceIndex, 1);
+  next.splice(targetIndex, 0, draggedProject);
+  return next;
+}
+
 interface ProjectViewState {
   selectedTaskId: string | null;
   isNewTask: boolean;
@@ -127,6 +140,7 @@ function App() {
   const [projectViews, setProjectViews] = useState<Record<string, ProjectViewState>>({});
   const [mountedProjectIds, setMountedProjectIds] = useState<string[]>([]);
   const [taskRunCounts, setTaskRunCounts] = useState<Record<string, number>>({});
+  const projectsRef = useRef<Project[]>([]);
 
   const tm = useTerminalManager();
 
@@ -166,6 +180,10 @@ function App() {
   function getProjectView(projectId: string): ProjectViewState {
     return projectViews[projectId] ?? createDefaultProjectViewState();
   }
+
+  useEffect(() => {
+    projectsRef.current = projects;
+  }, [projects]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
@@ -290,6 +308,22 @@ function App() {
       showToast(t("toast.initProjectConfigFailed", { error: String(e) }), "warning");
     });
   }
+
+  const handleReorderProjects = useCallback(
+    (draggedProjectId: string, targetProjectId: string) => {
+      setProjects((prev) => {
+        const next = reorderProjects(prev, draggedProjectId, targetProjectId);
+        if (next === prev) return prev;
+        projectsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handlePersistProjectOrder = useCallback(() => {
+    persistProjects(projectsRef.current, showToast);
+  }, [showToast]);
 
   function handleBack() {
     setActiveProject(null);
@@ -651,7 +685,7 @@ function App() {
     [projects],
   );
   const railProjects = useMemo(
-    () => [...projects].sort((a, b) => Number(a.id) - Number(b.id)),
+    () => [...projects],
     [projects],
   );
   const mountedProjects = useMemo(
@@ -708,6 +742,8 @@ function App() {
               onSnapshot={tm.handleSnapshot}
               onBack={handleBack}
               onSwitchProject={handleProjectClick}
+              onReorderProjects={handleReorderProjects}
+              onPersistProjectOrder={handlePersistProjectOrder}
               onOpen={handleOpen}
               isDark={isDark}
               themeMode={themeMode}

--- a/src/components/ProjectPage.tsx
+++ b/src/components/ProjectPage.tsx
@@ -56,6 +56,8 @@ export function ProjectPage({
   onSnapshot,
   onBack,
   onSwitchProject,
+  onReorderProjects,
+  onPersistProjectOrder,
   onOpen,
   isDark,
   themeMode,
@@ -111,6 +113,8 @@ export function ProjectPage({
   onSnapshot: (taskId: string, snapshot: string) => void;
   onBack: () => void;
   onSwitchProject: (project: Project) => void;
+  onReorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
+  onPersistProjectOrder: () => void;
   onOpen: () => void;
   isDark: boolean;
   themeMode: ThemeMode;
@@ -240,6 +244,8 @@ export function ProjectPage({
         allTasks={tasks}
         activeProjectId={project.id}
         onSwitch={onSwitchProject}
+        onReorderProjects={onReorderProjects}
+        onPersistProjectOrder={onPersistProjectOrder}
         onOpen={onOpen}
       />
       <TaskPanel

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { Plus, ChevronsRight } from "lucide-react";
 import type { Project, Task } from "../types";
 import { ProjectAvatar } from "./ProjectAvatar";
@@ -37,19 +37,56 @@ function RailItem({
   project,
   isActive,
   status,
+  isDragging,
+  isDragTarget,
   onSwitch,
+  onPointerDown,
+  onMount,
 }: {
   project: Project;
   isActive: boolean;
   status: ProjectStatus;
+  isDragging: boolean;
+  isDragTarget: boolean;
   onSwitch: (p: Project) => void;
+  onPointerDown: (
+    projectId: string,
+    event: {
+      x: number;
+      y: number;
+      offsetX: number;
+      offsetY: number;
+      width: number;
+      height: number;
+      pointerId: number;
+      node: HTMLButtonElement;
+    },
+  ) => void;
+  onMount: (projectId: string, node: HTMLButtonElement | null) => void;
 }) {
   const [hov, setHov] = useState(false);
+  const transform = isDragging ? "scale(0.92)" : isDragTarget ? "scale(1.04)" : "translate3d(0, 0, 0)";
 
   return (
     <button
+      ref={(node) => onMount(project.id, node)}
       title={project.name}
+      data-project-rail-id={project.id}
       onClick={() => onSwitch(project)}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        const rect = event.currentTarget.getBoundingClientRect();
+        onPointerDown(project.id, {
+          x: event.clientX,
+          y: event.clientY,
+          offsetX: event.clientX - rect.left,
+          offsetY: event.clientY - rect.top,
+          width: rect.width,
+          height: rect.height,
+          pointerId: event.pointerId,
+          node: event.currentTarget,
+        });
+      }}
       onMouseEnter={() => setHov(true)}
       onMouseLeave={() => setHov(false)}
       className={isActive ? "rail-active" : undefined}
@@ -60,23 +97,74 @@ function RailItem({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "none",
+        background: isDragTarget ? "var(--accent-subtle)" : "none",
         border: "none",
         borderRadius: 10,
-        cursor: isActive ? "default" : "pointer",
+        cursor: isDragging ? "grabbing" : isActive ? "grab" : "pointer",
         padding: 0,
+        touchAction: "none",
+        userSelect: "none",
+        opacity: isDragging ? 0.16 : 1,
+        transform,
+        zIndex: isDragging ? 1 : 0,
+        boxShadow: isDragTarget ? "0 4px 12px rgba(0,0,0,0.12)" : "none",
         outline: isActive
           ? "2px solid var(--accent)"
+          : isDragTarget
+            ? "2px solid var(--accent)"
           : hov
             ? "2px solid var(--border-medium)"
             : "2px solid transparent",
         outlineOffset: 1,
-        transition: isActive ? "none" : "outline-color 0.12s",
+        transition:
+          "transform 0.18s ease, outline-color 0.12s, opacity 0.12s, background 0.12s, box-shadow 0.16s",
       }}
     >
       <ProjectAvatar name={project.name} size={28} />
       <StatusBadge status={status} />
     </button>
+  );
+}
+
+function DragPreview({
+  project,
+  status,
+  x,
+  y,
+  width,
+  height,
+}: {
+  project: Project;
+  status: ProjectStatus;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: x,
+        top: y,
+        width,
+        height,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: 10,
+        background: "color-mix(in srgb, var(--bg-sidebar) 84%, white 16%)",
+        boxShadow: "0 12px 28px rgba(0,0,0,0.24)",
+        transform: "scale(1.08)",
+        pointerEvents: "none",
+        zIndex: 999,
+      }}
+    >
+      <div style={{ position: "relative", width: 28, height: 28 }}>
+        <ProjectAvatar name={project.name} size={28} />
+        <StatusBadge status={status} />
+      </div>
+    </div>
   );
 }
 
@@ -213,18 +301,154 @@ export function ProjectRail({
   allTasks,
   activeProjectId,
   onSwitch,
+  onReorderProjects,
+  onPersistProjectOrder,
   onOpen,
 }: {
   projects: Project[];
   allTasks: Task[];
   activeProjectId: string;
   onSwitch: (project: Project) => void;
+  onReorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
+  onPersistProjectOrder: () => void;
   onOpen: () => void;
 }) {
   const { t } = useI18n();
   const [addHov, setAddHov] = useState(false);
   const [expandHov, setExpandHov] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [draggedProjectId, setDraggedProjectId] = useState<string | null>(null);
+  const [dragTargetProjectId, setDragTargetProjectId] = useState<string | null>(null);
+  const [dragPreview, setDragPreview] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    offsetX: number;
+    offsetY: number;
+  } | null>(null);
+  const draggedProjectIdRef = useRef<string | null>(null);
+  const lastHoverProjectIdRef = useRef<string | null>(null);
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const dragMovedRef = useRef(false);
+  const reorderChangedRef = useRef(false);
+  const suppressClickRef = useRef(false);
+  const itemRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const previousTopsRef = useRef<Map<string, number>>(new Map());
+  const activePointerIdRef = useRef<number | null>(null);
+  const activePointerNodeRef = useRef<HTMLButtonElement | null>(null);
+
+  const clearDragState = useCallback(() => {
+    const activePointerId = activePointerIdRef.current;
+    const activePointerNode = activePointerNodeRef.current;
+    if (activePointerId !== null && activePointerNode?.hasPointerCapture(activePointerId)) {
+      activePointerNode.releasePointerCapture(activePointerId);
+    }
+    activePointerIdRef.current = null;
+    activePointerNodeRef.current = null;
+
+    if (reorderChangedRef.current) {
+      onPersistProjectOrder();
+    }
+    if (dragMovedRef.current) {
+      suppressClickRef.current = true;
+      window.setTimeout(() => {
+        suppressClickRef.current = false;
+      }, 0);
+    }
+    draggedProjectIdRef.current = null;
+    lastHoverProjectIdRef.current = null;
+    pointerStartRef.current = null;
+    reorderChangedRef.current = false;
+    setDragPreview(null);
+    setDraggedProjectId(null);
+    setDragTargetProjectId(null);
+    dragMovedRef.current = false;
+  }, [onPersistProjectOrder]);
+
+  function getProjectIdAtPoint(x: number, y: number): string | null {
+    const element = document.elementFromPoint(x, y);
+    const item = element?.closest("[data-project-rail-id]");
+    return item instanceof HTMLElement ? (item.dataset.projectRailId ?? null) : null;
+  }
+
+  useEffect(() => {
+    if (!draggedProjectId) return;
+
+    function handlePointerMove(event: PointerEvent) {
+      const start = pointerStartRef.current;
+      const draggedId = draggedProjectIdRef.current;
+      if (!start || !draggedId) return;
+
+      const distance = Math.hypot(event.clientX - start.x, event.clientY - start.y);
+      if (distance < 4) return;
+      dragMovedRef.current = true;
+
+      setDragPreview((prev) =>
+        prev
+          ? {
+              ...prev,
+              x: event.clientX - prev.offsetX,
+              y: event.clientY - prev.offsetY,
+            }
+          : prev,
+      );
+
+      const targetProjectId = getProjectIdAtPoint(event.clientX, event.clientY);
+      if (!targetProjectId || targetProjectId === lastHoverProjectIdRef.current) return;
+
+      lastHoverProjectIdRef.current = targetProjectId;
+      setDragTargetProjectId(targetProjectId);
+      if (targetProjectId !== draggedId) {
+        reorderChangedRef.current = true;
+        onReorderProjects(draggedId, targetProjectId);
+      }
+    }
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", clearDragState);
+    document.addEventListener("pointercancel", clearDragState);
+    window.addEventListener("blur", clearDragState);
+
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", clearDragState);
+      document.removeEventListener("pointercancel", clearDragState);
+      window.removeEventListener("blur", clearDragState);
+    };
+  }, [clearDragState, draggedProjectId, onReorderProjects]);
+
+  useLayoutEffect(() => {
+    const nextTops = new Map<string, number>();
+
+    projects.forEach((project) => {
+      const node = itemRefs.current[project.id];
+      if (!node) return;
+
+      const top = node.getBoundingClientRect().top;
+      nextTops.set(project.id, top);
+
+      const previousTop = previousTopsRef.current.get(project.id);
+      const delta = previousTop === undefined ? 0 : previousTop - top;
+      if (delta === 0 || project.id === draggedProjectId) return;
+
+      node.animate(
+        [
+          { transform: `translateY(${delta}px)` },
+          { transform: "translateY(0)" },
+        ],
+        {
+          duration: 180,
+          easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+        },
+      );
+    });
+
+    previousTopsRef.current = nextTops;
+  }, [projects, draggedProjectId]);
+
+  const draggedProject =
+    draggedProjectId ? projects.find((project) => project.id === draggedProjectId) ?? null : null;
 
   return (
     <div
@@ -250,9 +474,34 @@ export function ProjectRail({
           project={project}
           isActive={project.id === activeProjectId}
           status={getProjectStatus(allTasks, project.id)}
+          isDragging={draggedProjectId === project.id}
+          isDragTarget={dragTargetProjectId === project.id && draggedProjectId !== project.id}
           onSwitch={(p) => {
+            if (dragMovedRef.current || suppressClickRef.current) return;
             onSwitch(p);
             setDrawerOpen(false);
+          }}
+          onPointerDown={(projectId, event) => {
+            draggedProjectIdRef.current = projectId;
+            lastHoverProjectIdRef.current = projectId;
+            pointerStartRef.current = { x: event.x, y: event.y };
+            activePointerIdRef.current = event.pointerId;
+            activePointerNodeRef.current = event.node;
+            event.node.setPointerCapture(event.pointerId);
+            setDragPreview({
+              x: event.x - event.offsetX,
+              y: event.y - event.offsetY,
+              width: event.width,
+              height: event.height,
+              offsetX: event.offsetX,
+              offsetY: event.offsetY,
+            });
+            setDraggedProjectId(projectId);
+            dragMovedRef.current = false;
+            reorderChangedRef.current = false;
+          }}
+          onMount={(projectId, node) => {
+            itemRefs.current[projectId] = node;
           }}
         />
       ))}
@@ -313,6 +562,17 @@ export function ProjectRail({
       >
         <Plus size={14} strokeWidth={2.5} />
       </button>
+
+      {draggedProject && dragPreview && (
+        <DragPreview
+          project={draggedProject}
+          status={getProjectStatus(allTasks, draggedProject.id)}
+          x={dragPreview.x}
+          y={dragPreview.y}
+          width={dragPreview.width}
+          height={dragPreview.height}
+        />
+      )}
 
       {drawerOpen && (
         <ProjectDrawer


### PR DESCRIPTION
## Summary
- add drag-and-drop reordering support to the project rail
- persist reordered project list through the existing project save flow
- keep the PR scoped to ProjectRail/App/ProjectPage changes only

This is a clean replacement for #64, which used the fork main branch and included unrelated file search commits.

## Verification
- pnpm lint
- pnpm test