### PR TITLE
feat(running): show worktree branch info in task header

### DIFF
--- a/src/components/RunningView.tsx
+++ b/src/components/RunningView.tsx
@@ -16,6 +16,7 @@ import {
   Pencil,
   Sparkles,
   GitMerge,
+  GitBranch,
   Trash2,
   AlertTriangle,
   CheckCircle2,
@@ -418,6 +419,23 @@ export function RunningView({
               )
           )}
         </div>
+        {task.worktreePath && task.worktreeBranch && task.baseBranch && (
+          <div
+            title={t("running.worktreeBranchTitle", {
+              branch: task.worktreeBranch,
+              base: task.baseBranch,
+            })}
+            style={s.runMetaBranchRow}
+          >
+            <GitBranch size={11} strokeWidth={2.2} />
+            <span>
+              {t("running.worktreeBranchInfo", {
+                branch: task.worktreeBranch,
+                base: task.baseBranch,
+              })}
+            </span>
+          </div>
+        )}
         {sessionPath && (
           <div
             title={sessionPath}

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -325,6 +325,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "running.interruptedNoSession":
       "No session ID was saved for this task, so resume is unavailable. You can still cancel it or mark it completed.",
     "running.sessionFile": "Session file: {path}",
+    "running.worktreeBranchInfo": "Worktree: {branch} → {base}",
+    "running.worktreeBranchTitle": "Task is on branch {branch}, will merge into {base}",
     "running.duration": "Duration",
     "running.tokens": "Tokens",
     "running.context": "Context",
@@ -686,6 +688,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "running.interruptedNoSession":
       "这个任务没有保存会话 ID，因此暂时无法恢复；你仍然可以取消任务或标记已完成。",
     "running.sessionFile": "会话文件：{path}",
+    "running.worktreeBranchInfo": "工作树：{branch} → {base}",
+    "running.worktreeBranchTitle": "任务位于分支 {branch}，将合并回 {base}",
     "running.duration": "时长",
     "running.tokens": "Tokens",
     "running.context": "上下文",

--- a/src/styles/terminal.ts
+++ b/src/styles/terminal.ts
@@ -8,6 +8,18 @@ export const terminal = {
     gap: 10,
     flexShrink: 0,
   },
+  runMetaBranchRow: {
+    marginTop: 4,
+    display: "flex",
+    alignItems: "center",
+    gap: 5,
+    fontSize: 11,
+    color: "var(--text-muted)",
+    fontFamily: "var(--font-mono)",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+  },
   cancelBtn: {
     display: "flex",
     alignItems: "center",


### PR DESCRIPTION
Display the worktree branch and base branch on the running task view so users can see which branch the task is on and where it will merge back.