### PR TITLE
修复终端智能粘贴和文件拖拽路径

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ commit_prompt = "..."     # generate_commit_message 使用的提示词
 
 - 已开启严格模式（`tsconfig.json`）。避免使用 `any`，应扩展 `types.ts` 代替。
 - Tauri 命令使用 `invoke<ReturnType>()` 类型化——添加新命令时记得加泛型参数。
+- 终端键盘/粘贴/拖拽交互的共享前端逻辑放在 `src/components/terminalPasteDrop.ts`；`TerminalView` 和 `ShellTerminalPanel` 应复用同一套处理，避免 Codex 任务终端与内置 Shell 行为分叉。
 
 ### Rust
 

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -5,6 +5,7 @@ import { listen } from "@tauri-apps/api/event";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { attachSmartCopy } from "./terminalCopyHelper";
+import { attachTerminalPasteAndDrop } from "./terminalPasteDrop";
 import type { TerminalFontSize, FontFamily } from "../types";
 import {
   DARK_THEME,
@@ -152,6 +153,20 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         invoke("send_input", { taskId: shellId, data }).catch(() => {});
       });
       const disposeOnData = { dispose: () => linuxIME.dispose() };
+      const sendInput = (data: string) => {
+        invoke("send_input", { taskId: shellId, data }).catch(() => {});
+      };
+      const focusTerminal = () => {
+        window.requestAnimationFrame(() => {
+          term.focus();
+        });
+      };
+      const disposePasteAndDrop = attachTerminalPasteAndDrop({
+        container,
+        sendInput,
+        focusTerminal,
+        isActive: () => isActiveRef.current && terminalRef.current === term,
+      });
 
       const resizeObserver = new ResizeObserver(() => {
         setTimeout(() => {
@@ -198,6 +213,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         }
         unlisten?.();
         disposeSmartCopy();
+        disposePasteAndDrop();
         disposeOnData.dispose();
         resizeObserver.disconnect();
         document.removeEventListener("visibilitychange", handleVisibilityChange);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -3,6 +3,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { attachSmartCopy } from "./terminalCopyHelper";
+import { attachTerminalPasteAndDrop } from "./terminalPasteDrop";
 import type { TerminalFontSize, FontFamily } from "../types";
 import {
   DARK_THEME,
@@ -20,9 +21,7 @@ import "@xterm/xterm/css/xterm.css";
 interface TerminalViewProps {
   onInput: (data: string) => void;
   onResize: (cols: number, rows: number) => void;
-  onRegisterTerminal: (
-    writeFn: ((data: string, callback?: () => void) => void) | null,
-  ) => number;
+  onRegisterTerminal: (writeFn: ((data: string, callback?: () => void) => void) | null) => number;
   onReady?: (generation: number) => void;
   isDark: boolean;
   terminalFontSize: TerminalFontSize;
@@ -127,6 +126,12 @@ export function TerminalView({
     const disposeSmartCopy = attachSmartCopy(term);
     const linuxIME = attachLinuxIMEFix(term, (data) => onInputRef.current(data));
     const disposeOnData = { dispose: () => linuxIME.dispose() };
+    const disposePasteAndDrop = attachTerminalPasteAndDrop({
+      container,
+      sendInput: (data) => onInputRef.current(data),
+      focusTerminal,
+      isActive: () => terminalRef.current === term,
+    });
 
     const handlePointerDown = (e: PointerEvent) => {
       if (e.button === 0) {
@@ -175,6 +180,7 @@ export function TerminalView({
       fitAddonRef.current = null;
       disposeInputFix();
       disposeSmartCopy();
+      disposePasteAndDrop();
       disposeOnData.dispose();
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeObserver.disconnect();

--- a/src/components/terminalPasteDrop.ts
+++ b/src/components/terminalPasteDrop.ts
@@ -1,0 +1,199 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+const CTRL_V = "\x16";
+
+type DragDropPayload =
+  | { type: "drop"; paths: string[]; position?: { x: number; y: number } }
+  | { type: "over"; position?: { x: number; y: number } }
+  | { type: "enter"; paths?: string[]; position?: { x: number; y: number } }
+  | { type: "leave" }
+  | { type: "cancel" };
+
+interface AttachTerminalPasteAndDropOptions {
+  container: HTMLElement;
+  sendInput: (data: string) => void;
+  focusTerminal: () => void;
+  isActive?: () => boolean;
+}
+
+function isPasteShortcut(event: KeyboardEvent) {
+  return (
+    event.type === "keydown" &&
+    event.key.toLowerCase() === "v" &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
+function stopTerminalShortcut(event: Event) {
+  event.preventDefault();
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === "function") {
+    event.stopImmediatePropagation();
+  }
+}
+
+function isProbablyImageType(type: string) {
+  return type.toLowerCase().startsWith("image/");
+}
+
+function hasImageDataTransferItem(items: DataTransferItemList | undefined) {
+  if (!items) return false;
+  return Array.from(items).some((item) => isProbablyImageType(item.type));
+}
+
+function hasImageClipboardItem(items: ClipboardItem[] | undefined) {
+  if (!items) return false;
+  return items.some((item) => item.types.some(isProbablyImageType));
+}
+
+async function readClipboardTextFromItems(items: ClipboardItem[]) {
+  for (const item of items) {
+    if (!item.types.includes("text/plain")) continue;
+    const blob = await item.getType("text/plain");
+    const text = await blob.text();
+    if (text) return text;
+  }
+  return "";
+}
+
+async function pasteFromSystemClipboard(sendInput: (data: string) => void) {
+  try {
+    if (navigator.clipboard?.read) {
+      const items = await navigator.clipboard.read();
+      const text = await readClipboardTextFromItems(items);
+      if (text) {
+        sendInput(text);
+        return;
+      }
+      if (hasImageClipboardItem(items)) {
+        sendInput(CTRL_V);
+        return;
+      }
+    }
+  } catch {
+    // Fall through to readText. Some WebViews expose readText but deny read().
+  }
+
+  try {
+    const text = await navigator.clipboard?.readText?.();
+    if (text) {
+      sendInput(text);
+      return;
+    }
+  } catch {
+    // Preserve the terminal app's old Ctrl+V behavior when clipboard access is denied.
+  }
+
+  sendInput(CTRL_V);
+}
+
+function pathNeedsQuoting(path: string) {
+  return /[\s"'`$&|;<>()[\]{}*!?\\]/.test(path);
+}
+
+export function quotePathForTerminal(path: string) {
+  if (!pathNeedsQuoting(path)) return path;
+  return `'${path.replace(/'/g, `'\\''`)}'`;
+}
+
+export function formatDroppedPathsForTerminal(paths: string[]) {
+  return paths.map(quotePathForTerminal).join(" ") + (paths.length > 0 ? " " : "");
+}
+
+function isPointInsideElement(element: HTMLElement, point?: { x: number; y: number }) {
+  if (!point) return true;
+  const rect = element.getBoundingClientRect();
+  return (
+    point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom
+  );
+}
+
+function extractDomDroppedPaths(event: DragEvent) {
+  return Array.from(event.dataTransfer?.files ?? [])
+    .map((file) => {
+      const withPath = file as File & { path?: string };
+      return withPath.path || file.name;
+    })
+    .filter(Boolean);
+}
+
+function sendDroppedPaths(
+  paths: string[],
+  sendInput: (data: string) => void,
+  focusTerminal: () => void,
+) {
+  if (paths.length === 0) return;
+  focusTerminal();
+  sendInput(formatDroppedPathsForTerminal(paths));
+}
+
+export function attachTerminalPasteAndDrop({
+  container,
+  sendInput,
+  focusTerminal,
+  isActive = () => true,
+}: AttachTerminalPasteAndDropOptions) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!isActive() || !isPasteShortcut(event)) return;
+    stopTerminalShortcut(event);
+    focusTerminal();
+    void pasteFromSystemClipboard(sendInput);
+  };
+
+  const handlePaste = (event: ClipboardEvent) => {
+    if (!isActive()) return;
+    const text = event.clipboardData?.getData("text/plain") ?? "";
+    const hasImage = hasImageDataTransferItem(event.clipboardData?.items);
+    if (!text && !hasImage) return;
+    stopTerminalShortcut(event);
+    focusTerminal();
+    sendInput(text || CTRL_V);
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    if (!isActive()) return;
+    if ((event.dataTransfer?.types ?? []).includes("Files")) {
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+    }
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    if (!isActive()) return;
+    const paths = extractDomDroppedPaths(event);
+    if (paths.length === 0) return;
+    stopTerminalShortcut(event);
+    sendDroppedPaths(paths, sendInput, focusTerminal);
+  };
+
+  container.addEventListener("keydown", handleKeyDown, true);
+  container.addEventListener("paste", handlePaste, true);
+  container.addEventListener("dragover", handleDragOver);
+  container.addEventListener("drop", handleDrop);
+
+  let unlistenTauriDrop: (() => void) | null = null;
+  void getCurrentWebview()
+    .onDragDropEvent((event) => {
+      if (!isActive()) return;
+      const payload = event.payload as DragDropPayload;
+      if (payload.type !== "drop") return;
+      if (!isPointInsideElement(container, payload.position)) return;
+      sendDroppedPaths(payload.paths, sendInput, focusTerminal);
+    })
+    .then((unlisten) => {
+      unlistenTauriDrop = unlisten;
+    })
+    .catch(() => {
+      // Browser-only tests and previews do not provide the Tauri webview API.
+    });
+
+  return () => {
+    container.removeEventListener("keydown", handleKeyDown, true);
+    container.removeEventListener("paste", handlePaste, true);
+    container.removeEventListener("dragover", handleDragOver);
+    container.removeEventListener("drop", handleDrop);
+    unlistenTauriDrop?.();
+  };
+}

--- a/src/test/terminal-paste-drop.test.ts
+++ b/src/test/terminal-paste-drop.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(vi.fn()),
+  }),
+}));
+
+import {
+  formatDroppedPathsForTerminal,
+  quotePathForTerminal,
+} from "../components/terminalPasteDrop";
+
+describe("terminal dropped path formatting", () => {
+  test("leaves simple paths unquoted", () => {
+    expect(quotePathForTerminal("/tmp/file.txt")).toBe("/tmp/file.txt");
+  });
+
+  test("quotes paths with spaces and shell metacharacters", () => {
+    expect(quotePathForTerminal("C:\\Users\\Me\\My File.txt")).toBe("'C:\\Users\\Me\\My File.txt'");
+    expect(quotePathForTerminal("/tmp/it's here.txt")).toBe("'/tmp/it'\\''s here.txt'");
+  });
+
+  test("joins multiple dropped paths with trailing insertion space", () => {
+    expect(formatDroppedPathsForTerminal(["/tmp/a.txt", "/tmp/b file.txt"])).toBe(
+      "/tmp/a.txt '/tmp/b file.txt' ",
+    );
+  });
+});


### PR DESCRIPTION
## 变更
- 新增终端共享粘贴/拖拽处理，复用于 Codex/Claude 任务终端和内置 Shell 终端
- 拦截 Ctrl/Cmd+V：优先读取文字剪贴板并发送到 PTY；剪贴板是图片或读取失败时保留 Ctrl+V 语义，避免 Codex 误判纯文本粘贴
- 支持拖拽文件到终端区域时把路径自动插入终端，并对空格/特殊字符路径做 shell 安全引号处理
- 补充路径格式化单测和 AGENTS 维护记录

## 验证
- pnpm lint
- pnpm build
- pnpm test

## 说明
- 本次只改前端事件层，不改 PTY 后端协议和任务数据结构
- Tauri 原生拖拽事件用于拿真实文件路径；DOM drop 作为浏览器预览/测试兜底