### PR TITLE
fix: 设置面板代码字体预览不随选择变化

### DIFF
--- a/src/components/app-settings/FontPanel.tsx
+++ b/src/components/app-settings/FontPanel.tsx
@@ -135,43 +135,41 @@ export function FontPanel({
           <div style={s.fontInlinePreview}>
             <div style={s.fontPreviewHeaderRow}>
               <span style={s.fontPreviewLabel}>{t("font.preview")}</span>
-              <span style={{ ...s.fontPreviewMeta, fontFamily: pendingMonoFont }}>0O · 1lI · {}[]()</span>
+              <span style={s.fontPreviewMeta}>0O · 1lI · {}[]()</span>
             </div>
-            <pre
+            <div
               style={{
                 ...s.fontCodePreviewWindow,
                 fontFamily: pendingMonoFont,
               }}
             >
-              <code>
-                <span style={s.fontCodeLine}>
-                  <span style={s.fontCodeLineNo}>1</span>
-                  <span style={s.fontCodeText}>
-                    <span style={s.fontCodeKeyword}>const</span> task = {"{"}
-                  </span>
+              <span style={s.fontCodeLine}>
+                <span style={s.fontCodeLineNo}>1</span>
+                <span style={s.fontCodeText}>
+                  <span style={s.fontCodeKeyword}>const</span> task = {"{"}
                 </span>
-                <span style={s.fontCodeLine}>
-                  <span style={s.fontCodeLineNo}>2</span>
-                  <span style={s.fontCodeText}>
-                    {"  "}name: <span style={s.fontCodeString}>"Nezha"</span>,
-                    status: <span style={s.fontCodeString}>"running"</span>,
-                  </span>
+              </span>
+              <span style={s.fontCodeLine}>
+                <span style={s.fontCodeLineNo}>2</span>
+                <span style={s.fontCodeText}>
+                  {"  "}name: <span style={s.fontCodeString}>"Nezha"</span>,
+                  status: <span style={s.fontCodeString}>"running"</span>,
                 </span>
-                <span style={s.fontCodeLine}>
-                  <span style={s.fontCodeLineNo}>3</span>
-                  <span style={s.fontCodeText}>
-                    {"  "}tokens: <span style={s.fontCodeNumber}>24860</span>,
-                    tools: [<span style={s.fontCodeString}>"read"</span>, <span style={s.fontCodeString}>"edit"</span>],
-                  </span>
+              </span>
+              <span style={s.fontCodeLine}>
+                <span style={s.fontCodeLineNo}>3</span>
+                <span style={s.fontCodeText}>
+                  {"  "}tokens: <span style={s.fontCodeNumber}>24860</span>,
+                  tools: [<span style={s.fontCodeString}>"read"</span>, <span style={s.fontCodeString}>"edit"</span>],
                 </span>
-                <span style={s.fontCodeLine}>
-                  <span style={s.fontCodeLineNo}>4</span>
-                  <span style={s.fontCodeText}>
-                    {"}"} <span style={s.fontCodeComment}>// 0O 1lI == =&gt; =&lt; =&gt;</span>
-                  </span>
+              </span>
+              <span style={s.fontCodeLine}>
+                <span style={s.fontCodeLineNo}>4</span>
+                <span style={s.fontCodeText}>
+                  {"}"} <span style={s.fontCodeComment}>// 0O 1lI == =&gt; =&lt; =&gt;</span>
                 </span>
-              </code>
-            </pre>
+              </span>
+            </div>
           </div>
         )}
       />


### PR DESCRIPTION
Closes #177

## 改动

将代码字体预览中的 `<pre><code>` 替换为 `<div>`，同时去掉右侧辅助文字 `0O · 1lI · {}[]()` 上的 `fontFamily`。

### 原因
浏览器默认给 `code` 元素设置了 `font-family: monospace`，截断了从 `<pre>` 继承的内联 `fontFamily`，导致选中的字体无法生效。

### 测试
在设置 → 字体面板切换不同的代码字体，确认预览区域正确跟随变化。