### PR TITLE
fix(terminal): mitigate macOS NSTextInput hit-test storm

### DIFF
--- a/knowledge/xterm/rendering-and-selection-lag.md
+++ b/knowledge/xterm/rendering-and-selection-lag.md
@@ -90,6 +90,143 @@ Nezha 的工作流以"鼠标在终端区域活动"为主（hover、点击、移�
 
 ---
 
+## 7. macOS NSTextInputClient 风暴（与 §4 完全无关的另一条路径）
+
+> 这是 2026-05-19 实测发现的**独立卡顿来源**，sample 工具锁定。和 §1–§4 的 composite 长帧不是同一回事，**先看现象判断走哪条路径**：
+
+| 现象 | 路径 |
+|---|---|
+| 鼠标在终端上移动时持续小卡顿 | §1–§4 composite/layout（保持 WebGL，不要加 containment） |
+| 框选大段文本后 / 长会话运行很久后突发 100% CPU 卡死，reload 立刻好 | §7 NSTextInput 风暴（本节） |
+
+### 7.1 现场
+
+- pid 持续 100% CPU、状态 `R`
+- `sample <pid> 5` 主线程 99.7% 在：
+  ```
+  IPC::handleMessageAsync<WebPage::CharacterIndexForPointAsync>
+  └─ LocalFrame::rangeForPoint
+     ├─ visiblePositionForPoint (HitTest)
+     └─ canonicalPosition → PositionIterator::increment × 1500+
+        └─ RenderText::nextOffset → CachedTextBreakIterator::setText
+           → CFStringCreateImmutable / CFRelease（ICU emoji grapheme 簇）
+           → __CFStringGetExtendedPictographicSequenceComponent
+  ```
+- reload 后立刻归零，物理内存 1.2G → 493M
+
+### 7.2 触发链
+
+1. xterm v6 即使在 WebGL renderer 下，`_rowFactory.createRow()` 仍然往每个 row div `replaceChildren(...spans)` 写入完整字符内容（让浏览器原生 selection/copy 工作）
+2. 长会话 + Claude Code 输出含大量 emoji / box drawing / Unicode → 每个 row span 都需要走 ICU pictographic 簇判断
+3. 用户在 xterm 内拖选 → macOS 进入"有 selection 的文本输入状态" → NSTextInputClient（IME 候选词浮窗追踪 / 拼写检查 / AX）**持续轮询** `characterIndexForPointAsync`
+4. 单次查询 → `canonicalPosition` 在整棵 xterm-rows 子树游走 1500+ RenderText → 50–200ms
+5. 主线程被卡 → 后续事件堆积 → 系统继续轮询 → 正反馈到 100%
+
+### 7.3 修复（分两档落地）
+
+修复 V1 单独不够——实测仍有 ~20% IME 路径占主线程（拖选时偶发卡顿）。完整修复包含 V1 + V2 两层：
+
+**V1：CSS 阻断 hit-test 入口**
+
+`src/App.css`：
+```css
+.xterm-rows,
+.xterm-rows * { pointer-events: none; }
+```
+
+`src/components/TerminalView.tsx`（关掉 helper textarea 上的 macOS 自动行为）：
+```ts
+term.textarea.setAttribute("autocomplete", "off");
+term.textarea.setAttribute("autocorrect", "off");
+term.textarea.setAttribute("autocapitalize", "off");
+term.textarea.setAttribute("spellcheck", "false");
+```
+
+实测把 `CharacterIndexForPointAsync` 主线程占比从 **99.7% → 20.6%**。`pointer-events: none` 拦住了 WebKit hit-test 命中 row 子树，但 `canonicalPosition` 仍会从外层 hit-test 结果向前/向后游走候选 Position，进入 row span 的 RenderText——这一步不看 pointer-events。所以 V1 单独不够。
+
+**V2：MutationObserver 替换 row span 文本为 ASCII**
+
+`src/components/TerminalView.tsx` 的 `useEffect` 内：
+```ts
+const rowsEl = container.querySelector(".xterm-rows");
+const processedSpans = new WeakSet<Element>();
+const ASCII_ONLY = /^[\x20-\x7E]*$/;
+const rowSanitizer = new MutationObserver((mutations) => {
+  for (const m of mutations) {
+    if (m.type !== "childList") continue;
+    for (const n of m.addedNodes) {
+      if (n.nodeType !== Node.ELEMENT_NODE) continue;
+      const el = n as Element;
+      if (el.tagName !== "SPAN" || processedSpans.has(el)) continue;
+      const text = el.textContent;
+      if (!text || text.length <= 1 || ASCII_ONLY.test(text)) {
+        processedSpans.add(el);
+        continue;
+      }
+      el.textContent = "x";
+      processedSpans.add(el);
+    }
+  }
+});
+rowSanitizer.observe(rowsEl, { childList: true, subtree: true });
+```
+
+xterm v6 每帧 `_rowFactory.createRow()` → `rowDiv.replaceChildren(...newSpans)`，触发 MutationRecord。我们 hook 到 addedNodes 里的 span，把含非 ASCII 字符（emoji / box drawing）的 textContent 替换成单字符 `"x"`。
+
+PositionIterator 仍游走 1500+ 次（这是 WebKit 内部行为，CSS / JS 都改不了），但每次 ICU TextBreakIterator setText 走 ASCII fast path——不再进入 `__CFStringGetExtendedPictographicSequenceComponent` 的 emoji 簇判断。
+
+为什么 V2 不会破坏 xterm：
+- xterm 的拖选用 `mouseService.getCoords(event, screenElement)`——读 event clientX/Y + screenElement boundingRect，不读 row span 内容
+- xterm 的列宽对齐用 `_rowColumns.set(span, [...])` 存的期望列范围，**与 span.textContent 内容无关**；`_alignRowWidth(rowDiv)` 用 row div 的 boundingRect 算 scaleX，row div 内 span 只要还有内容（"x"）就不会触发除零
+- xterm 的字符渲染是 WebGL canvas 上做的，**row span 视觉上被 canvas 覆盖**，textContent 改成什么都看不见
+- Nezha 的复制走 `attachSmartCopy` → `terminal.buffer.translateToString` → 直接读 xterm core buffer，**完全不读 DOM**
+- WeakSet 去重避免我们自己写入 textContent 触发的二次 mutation 死循环——`span.textContent = "x"` 会触发新一次 childList mutation（addedNodes 是 text node，不是 SPAN），回调里 `tagName !== "SPAN"` 直接跳过
+
+### 7.4 诊断小抄（覆盖原 §5）
+
+下次终端卡顿先按这个走，**不要先怀疑 PTY backpressure / SmartWriter / IPC backlog**——这些都是猜测，浪费时间：
+
+```bash
+# 1. 找到 100% 的 WebContent pid（多个 WebContent 进程时挑 nezha 那个）
+ps aux | grep WebKit.WebContent | grep -v grep | sort -k3 -rn | head
+
+# 2. 采样 5–8 秒
+sample <pid> 5 -file /tmp/nezha.sample
+
+# 3. 看顶部 100 行栈
+head -100 /tmp/nezha.sample
+```
+
+判断分支：
+
+- 主线程顶部出现 **`CharacterIndexForPointAsync` / `LocalFrame::rangeForPoint` / `CFStringGetExtendedPictographicSequenceComponent`** → §7 NSTextInput 风暴
+- 主线程顶部是 **composite / paint / layout** → §4 那张 A/B/C/D 表覆盖的路径
+- 主线程顶部是 **JS / IPC dispatch / mach_msg 收消息频繁** → 应用层（前端 React rerender / 后端 emit 风暴）
+
+**A/B 对照实验**（验证修复是否有效）：
+1. 在 release 版重新构建后运行
+2. 长输出任务跑到累积 5MB+ scrollback
+3. 在终端拖选跨多屏的范围，松手
+4. `sample <pid> 5` 看 `CharacterIndexForPointAsync` 是否消失
+5. 应为 0 → 修复生效
+
+### 7.5 fix_oom 分支与此问题无关
+
+`fix_oom` 分支的 PTY backpressure 改动（`set_pty_paused` / `paused_flag` / SmartWriter `onPauseChange`）跟本节无关——sample 期间 PTY/IPC 路径 0 个采样。可以独立评估 backpressure 是否真的能防 OOM，但不要用它修这个 CPU 100% 现场。
+
+---
+
+## 8. 已知缺口（未修，留给后续）
+
+| 缺口 | 影响 | 触发条件 |
+|---|---|---|
+| `selectionPaused = true` 后 pointerup 丢失（pointercancel / 系统手势 / 拖出窗外） | SmartWriter `pendingChunks` 无上限增长直到下次成功 pointerdown→pointerup | 鼠标手势打断选区拖动 |
+| `webglAddon.onContextLoss` 只 dispose 不 re-attach | context loss 后变成 DOM renderer，§3 的负向交易开始生效 | GPU 内存压力 / 系统休眠 |
+| `SessionView` 同步 `marked(async:false)` + 全文件加载 JSONL | JS 堆短期飙升，加重高分配率（但与本文卡顿不直接相关） | 打开很长的 session |
+| §7 修复 V1+V2 实测前主线程峰值已从 99% 持续不降变为偶发短卡，但**未经长跑长会话+多终端实例的稳定性验证**。MutationObserver 跟 xterm DOM 写入对抗，xterm v6 升级如改 row 创建路径需要回归测试 | 修复需要长期 monitoring | xterm v6 主版本升级后 |
+
+---
+
 **相关：**
 
 - [`AGENTS.md`](../../AGENTS.md) — 防劣化规则的终端相关条目

--- a/knowledge/xterm/rendering-and-selection-lag.md
+++ b/knowledge/xterm/rendering-and-selection-lag.md
@@ -14,7 +14,7 @@
 | `.xterm { contain / isolation / will-change / 3D transform }` | **禁用** | 不要重新加任何一条 | `src/App.css` 上 `.xterm` 选择器位置已替换为防回归注释段 |
 | `WebglAddon` | **启用** | 不要关 / 不要改 noop | `src/components/terminalShared.ts::loadWebglAddon` |
 | `createSmartWriter` watermark 128KB/16KB | 保留 | 数值可调，不能取消 | `src/components/terminalShared.ts::createSmartWriter` |
-| `selectionPaused` 的 pointerup 监听挂 `document` | 保留 | 不要挪到 container（拖出窗外漏 pointerup） | `src/components/TerminalView.tsx` useEffect |
+| macOS WebKit terminal guard | 保留 | 不要删 inert / xterm selection 监听 / document 级 pointerup | `src/components/terminalShared.ts::attachMacWebKitTerminalGuard` |
 | `tauri::ipc::Channel` 直投 agent 输出 | 保留 | 不要换回 `emit/listen` | `src-tauri/src/pty.rs::OutputSink::Channel` |
 
 ---
@@ -92,7 +92,7 @@ Nezha 的工作流以"鼠标在终端区域活动"为主（hover、点击、移�
 
 ## 7. macOS NSTextInputClient 风暴（与 §4 完全无关的另一条路径）
 
-> 这是 2026-05-19 实测发现的**独立卡顿来源**，sample 工具锁定。和 §1–§4 的 composite 长帧不是同一回事，**先看现象判断走哪条路径**：
+> 这是 2026-05-19 实测发现、2026-05-22 重新核对过的**独立卡顿来源**，sample 工具锁定。和 §1–§4 的 composite 长帧不是同一回事，**先看现象判断走哪条路径**：
 
 | 现象 | 路径 |
 |---|---|
@@ -116,71 +116,22 @@ Nezha 的工作流以"鼠标在终端区域活动"为主（hover、点击、移�
 
 ### 7.2 触发链
 
-1. xterm v6 即使在 WebGL renderer 下，`_rowFactory.createRow()` 仍然往每个 row div `replaceChildren(...spans)` 写入完整字符内容（让浏览器原生 selection/copy 工作）
-2. 长会话 + Claude Code 输出含大量 emoji / box drawing / Unicode → 每个 row span 都需要走 ICU pictographic 簇判断
-3. 用户在 xterm 内拖选 → macOS 进入"有 selection 的文本输入状态" → NSTextInputClient（IME 候选词浮窗追踪 / 拼写检查 / AX）**持续轮询** `characterIndexForPointAsync`
-4. 单次查询 → `canonicalPosition` 在整棵 xterm-rows 子树游走 1500+ RenderText → 50–200ms
-5. 主线程被卡 → 后续事件堆积 → 系统继续轮询 → 正反馈到 100%
+1. WebGL renderer 启用后，xterm v6 会同步 dispose DOM renderer，当前 `.xterm-rows` 不存在；旧文档里“WebGL 仍写 row span”的模型是错的。
+2. 用户在 xterm 内拖选或保留 selection 后，macOS NSTextInputClient（IME 候选词浮窗追踪 / 拼写检查 / AX）会持续轮询 `characterIndexForPointAsync`。2026-05-22 的 Timeline 录制显示，即使没有 pointerdown、只有 mousemove，也可能进入持续轮询。
+3. WebKit 处理单次查询时走 `LocalFrame::rangeForPoint` → `canonicalPosition` → `PositionIterator::increment`。sample 栈里出现 `HTMLImageElement::canContainRangeEndPoint`，说明游走目标不是 `.xterm-rows`，而是 Nezha 自己的含 `<img>`/emoji 的 DOM 子树（task list、project rail、session markdown 等）。
+4. 单次查询可能花 50–200ms；macOS 进入持续轮询后，主线程 CPU 正反馈到 100%。Safari Timeline 通常只看到短事件和 CPU 飙升，看不到 WebKit C++ 层长任务。
 
-### 7.3 修复（分两档落地）
+### 7.3 当前防线
 
-修复 V1 单独不够——实测仍有 ~20% IME 路径占主线程（拖选时偶发卡顿）。完整修复包含 V1 + V2 两层：
+当前防线在 `src/components/terminalShared.ts::attachMacWebKitTerminalGuard`，agent 终端和 shell 终端都必须使用：
 
-**V1：CSS 阻断 hit-test 入口**
+1. 给终端容器加 `.xterm-macos-ime-guard`。`src/styles/xterm.css` 的 `.xterm-rows { pointer-events: none }` 现在主要是 WebGL context loss / DOM renderer fallback，不是当前主路径。
+2. 关掉 helper textarea 的 `autocomplete` / `autocorrect` / `autocapitalize` / `spellcheck`，减少 macOS 主动文本定位查询。
+3. 通过 xterm 自己的 `onSelectionChange` / `hasSelection()` 判断终端是否有 selection。不要用 `window.getSelection()`，WebGL renderer 下 xterm selection 不等价于浏览器原生 selection。
+4. selection 或拖选期间，把“终端到 `body` 祖先链上的所有兄弟子树”设置为 `inert`。不要只遍历 `document.body.children`：React 应用通常只有一个 `#root`，直接子节点方案会跳过整个应用，实际 inert 不到 task list / project rail。
+5. `pointerup` / `pointercancel` 挂 `document`，避免拖出终端后漏恢复；点击终端外或按 Escape 时清除 selection 并恢复 inert。
 
-`src/App.css`：
-```css
-.xterm-rows,
-.xterm-rows * { pointer-events: none; }
-```
-
-`src/components/TerminalView.tsx`（关掉 helper textarea 上的 macOS 自动行为）：
-```ts
-term.textarea.setAttribute("autocomplete", "off");
-term.textarea.setAttribute("autocorrect", "off");
-term.textarea.setAttribute("autocapitalize", "off");
-term.textarea.setAttribute("spellcheck", "false");
-```
-
-实测把 `CharacterIndexForPointAsync` 主线程占比从 **99.7% → 20.6%**。`pointer-events: none` 拦住了 WebKit hit-test 命中 row 子树，但 `canonicalPosition` 仍会从外层 hit-test 结果向前/向后游走候选 Position，进入 row span 的 RenderText——这一步不看 pointer-events。所以 V1 单独不够。
-
-**V2：MutationObserver 替换 row span 文本为 ASCII**
-
-`src/components/TerminalView.tsx` 的 `useEffect` 内：
-```ts
-const rowsEl = container.querySelector(".xterm-rows");
-const processedSpans = new WeakSet<Element>();
-const ASCII_ONLY = /^[\x20-\x7E]*$/;
-const rowSanitizer = new MutationObserver((mutations) => {
-  for (const m of mutations) {
-    if (m.type !== "childList") continue;
-    for (const n of m.addedNodes) {
-      if (n.nodeType !== Node.ELEMENT_NODE) continue;
-      const el = n as Element;
-      if (el.tagName !== "SPAN" || processedSpans.has(el)) continue;
-      const text = el.textContent;
-      if (!text || text.length <= 1 || ASCII_ONLY.test(text)) {
-        processedSpans.add(el);
-        continue;
-      }
-      el.textContent = "x";
-      processedSpans.add(el);
-    }
-  }
-});
-rowSanitizer.observe(rowsEl, { childList: true, subtree: true });
-```
-
-xterm v6 每帧 `_rowFactory.createRow()` → `rowDiv.replaceChildren(...newSpans)`，触发 MutationRecord。我们 hook 到 addedNodes 里的 span，把含非 ASCII 字符（emoji / box drawing）的 textContent 替换成单字符 `"x"`。
-
-PositionIterator 仍游走 1500+ 次（这是 WebKit 内部行为，CSS / JS 都改不了），但每次 ICU TextBreakIterator setText 走 ASCII fast path——不再进入 `__CFStringGetExtendedPictographicSequenceComponent` 的 emoji 簇判断。
-
-为什么 V2 不会破坏 xterm：
-- xterm 的拖选用 `mouseService.getCoords(event, screenElement)`——读 event clientX/Y + screenElement boundingRect，不读 row span 内容
-- xterm 的列宽对齐用 `_rowColumns.set(span, [...])` 存的期望列范围，**与 span.textContent 内容无关**；`_alignRowWidth(rowDiv)` 用 row div 的 boundingRect 算 scaleX，row div 内 span 只要还有内容（"x"）就不会触发除零
-- xterm 的字符渲染是 WebGL canvas 上做的，**row span 视觉上被 canvas 覆盖**，textContent 改成什么都看不见
-- Nezha 的复制走 `attachSmartCopy` → `terminal.buffer.translateToString` → 直接读 xterm core buffer，**完全不读 DOM**
-- WeakSet 去重避免我们自己写入 textContent 触发的二次 mutation 死循环——`span.textContent = "x"` 会触发新一次 childList mutation（addedNodes 是 text node，不是 SPAN），回调里 `tagName !== "SPAN"` 直接跳过
+旧的 MutationObserver row sanitizer 已删除：WebGL 正常启用时 `.xterm-rows` 已被同步移除，observer 找不到目标，是死代码。
 
 ### 7.4 诊断小抄（覆盖原 §5）
 
@@ -220,10 +171,9 @@ head -100 /tmp/nezha.sample
 
 | 缺口 | 影响 | 触发条件 |
 |---|---|---|
-| `selectionPaused = true` 后 pointerup 丢失（pointercancel / 系统手势 / 拖出窗外） | SmartWriter `pendingChunks` 无上限增长直到下次成功 pointerdown→pointerup | 鼠标手势打断选区拖动 |
 | `webglAddon.onContextLoss` 只 dispose 不 re-attach | context loss 后变成 DOM renderer，§3 的负向交易开始生效 | GPU 内存压力 / 系统休眠 |
 | `SessionView` 同步 `marked(async:false)` + 全文件加载 JSONL | JS 堆短期飙升，加重高分配率（但与本文卡顿不直接相关） | 打开很长的 session |
-| §7 修复 V1+V2 实测前主线程峰值已从 99% 持续不降变为偶发短卡，但**未经长跑长会话+多终端实例的稳定性验证**。MutationObserver 跟 xterm DOM 写入对抗，xterm v6 升级如改 row 创建路径需要回归测试 | 修复需要长期 monitoring | xterm v6 主版本升级后 |
+| §7 inert 防线需要真实长跑 sample 复验。代码已覆盖无 pointerdown 的已有 selection 场景，但 macOS 何时进入持续轮询仍由系统决定 | 修复需要长期 monitoring | 长会话、多终端实例、4K DPR 切换后 |
 
 ---
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 @import "./styles/themes.css";
 @import "./styles/font-selector.css";
+@import "./styles/xterm.css";
 
 /* ── Reset ─────────────────────────────────────────────────────── */
 *,

--- a/src/components/RunningView.tsx
+++ b/src/components/RunningView.tsx
@@ -7,6 +7,7 @@ import { TerminalView } from "./TerminalView";
 import { SessionView } from "./SessionView";
 import { shortenPath, getUsageColor } from "../utils";
 import { useUsageSnapshot } from "../hooks/useUsageSnapshot";
+import { useTerminalSelectionActive } from "../hooks/useTerminalSelectionActive";
 import { ENABLE_USAGE_INSIGHTS } from "../platform";
 import { useI18n } from "../i18n";
 import s from "../styles";
@@ -106,6 +107,7 @@ export function RunningView({
   const sessionPath = task.claudeSessionPath ?? task.codexSessionPath;
   const resumeSessionId = task.agent === "codex" ? task.codexSessionId : task.claudeSessionId;
   const restoreState = getRestoreState?.() ?? {};
+  const terminalSelectionActive = useTerminalSelectionActive();
 
   const { snapshot: usageSnapshot } = useUsageSnapshot(visible && ENABLE_USAGE_INSIGHTS);
 
@@ -160,7 +162,7 @@ export function RunningView({
     // 项目重新激活时这里会立即补拉一次。注意这里用的是 projectActive
     // 而不是 visible —— 后者在同项目内打开 FileViewer / GitDiff 时也会是 false，
     // 那种场景下不应该中断正在运行任务的 duration 更新。
-    if (!projectActive) return;
+    if (!projectActive || terminalSelectionActive) return;
 
     let cancelled = false;
 
@@ -187,7 +189,7 @@ export function RunningView({
     return () => {
       cancelled = true;
     };
-  }, [sessionPath, isActive, projectActive]);
+  }, [sessionPath, isActive, projectActive, terminalSelectionActive]);
 
   return (
     <div

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -13,6 +13,7 @@ import {
   loadWebglAddon,
   safeFit,
   createSmartWriter,
+  attachMacWebKitTerminalGuard,
   applyTerminalFontSize,
   applyTerminalFontFamily,
 } from "./terminalShared";
@@ -112,6 +113,8 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       term.open(container);
       const disposeInputFix = attachMacWebKitShiftInputFix(term);
       loadWebglAddon(term);
+      const writer = createSmartWriter(term);
+      const disposeMacWebKitGuard = attachMacWebKitTerminalGuard({ term, container, writer });
 
       const fit = () => {
         if (cleaned) return;
@@ -146,7 +149,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         }
       }, 50);
 
-      const writer = createSmartWriter(term);
       const disposeSmartCopy = attachSmartCopy(term);
       const linuxIME = attachLinuxIMEFix(term, (data) => {
         invoke("send_input", { taskId: shellId, data }).catch(() => {});
@@ -166,12 +168,11 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         if (document.visibilityState !== "visible" || !terminalRef.current || !isActiveRef.current) return;
         window.requestAnimationFrame(() => {
           fit();
-          const t = terminalRef.current;
-          if (t) {
-            t.refresh(0, t.rows - 1);
+        const t = terminalRef.current;
+        if (t) {
             t.focus();
-          }
-        });
+        }
+      });
       };
       document.addEventListener("visibilitychange", handleVisibilityChange);
 
@@ -203,6 +204,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         terminalRef.current = null;
         fitAddonRef.current = null;
+        disposeMacWebKitGuard();
         disposeInputFix();
         term.dispose();
         invoke("kill_shell", { shellId }).catch(() => {});
@@ -221,7 +223,6 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
             invoke("resize_pty", { taskId: shellId, cols: s.cols, rows: s.rows }).catch(() => {});
           }
         }
-        terminalRef.current.refresh(0, terminalRef.current.rows - 1);
         terminalRef.current.focus();
       });
     }, [isActive, shellId]);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -101,49 +101,6 @@ export function TerminalView({
     const disposeInputFix = attachMacWebKitShiftInputFix(term);
     loadWebglAddon(term);
 
-    // 拦截 xterm 每帧 _rowFactory.createRow → row div replaceChildren 写入的 span：
-    // 含非 ASCII（emoji / box drawing）的 textContent 立刻替换为单字符 "x"。
-    //
-    // styles/xterm.css 中 .xterm-rows pointer-events: none 拦掉了 macOS
-    // characterIndexForPointAsync 的 hit-test 入口，但 WebKit 的 canonicalPosition
-    // 仍会在 RenderTree 里向前/向后游走候选 Position，进入 row span 内的 RenderText
-    // ——这一步不看 pointer-events。实测把 IME 路径从 99.7% 压到 ~20%，剩下的就是
-    // canonicalPosition × PositionIterator::decrement/increment × ICU TextBreakIterator
-    // 在每个 RenderText 上做 emoji 簇判断 (__CFStringGetExtendedPictographicSequenceComponent)。
-    //
-    // 把非 ASCII 替换成单字符 ASCII 后：PositionIterator 仍游走 1500+ 次（这是 WebKit
-    // 内部行为，改不了），但每次 ICU setText 走 ASCII fast path 几乎免费。预期把 IME
-    // 路径再压到 <5%。row div 仍保留非零 boundingClientRect.width，xterm 的
-    // _alignRowWidth scaleX 校准不会触发除零；视觉上 row 子树本来就被 canvas 覆盖，
-    // 替换不影响显示。Cmd+C 复制走 attachSmartCopy → buffer.translateToString，不读 DOM。
-    //
-    // 详见 knowledge/xterm/rendering-and-selection-lag.md §7。
-    const rowsEl = container.querySelector(".xterm-rows");
-    const processedSpans = new WeakSet<Element>();
-    const ASCII_ONLY = /^[\x20-\x7E]*$/;
-    let rowSanitizer: MutationObserver | null = null;
-    if (IS_MAC_WEBKIT && rowsEl) {
-      rowSanitizer = new MutationObserver((mutations) => {
-        for (const m of mutations) {
-          if (m.type !== "childList") continue;
-          for (const n of m.addedNodes) {
-            if (n.nodeType !== Node.ELEMENT_NODE) continue;
-            const el = n as Element;
-            if (el.tagName !== "SPAN") continue;
-            if (processedSpans.has(el)) continue;
-            const text = el.textContent;
-            if (!text || text.length <= 1 || ASCII_ONLY.test(text)) {
-              processedSpans.add(el);
-              continue;
-            }
-            el.textContent = "x";
-            processedSpans.add(el);
-          }
-        }
-      });
-      rowSanitizer.observe(rowsEl, { childList: true, subtree: true });
-    }
-
     const size = safeFit(fitAddon, term);
     if (size) notifyResize(size.cols, size.rows);
 
@@ -229,7 +186,6 @@ export function TerminalView({
       } catch {
         /* ignore */
       }
-      rowSanitizer?.disconnect();
       container.classList.remove("xterm-macos-ime-guard");
       onRegisterRef.current(null);
       fitAddonRef.current = null;

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -11,11 +11,11 @@ import {
   loadWebglAddon,
   safeFit,
   createSmartWriter,
+  attachMacWebKitTerminalGuard,
   applyTerminalFontSize,
   applyTerminalFontFamily,
 } from "./terminalShared";
 import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
-import { IS_MAC_WEBKIT } from "../platform";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -84,20 +84,6 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
-    // 关掉 macOS 在 helper textarea 上的拼写检查 / 自动纠正 / 文本预测——
-    // 这些行为会主动触发 NSTextInputClient 的 characterIndexForPointAsync
-    // 查询。textarea 默认在屏幕外（left: -9999em），但 macOS 输入法仍可能
-    // 主动定位它。配合 src/styles/xterm.css 中 .xterm-rows 的 pointer-events: none
-    // 一起切断 IME 查询风暴的两条入口。详见 knowledge/xterm/rendering-and-selection-lag.md §7。
-    if (IS_MAC_WEBKIT) {
-      container.classList.add("xterm-macos-ime-guard");
-    }
-    if (IS_MAC_WEBKIT && term.textarea) {
-      term.textarea.setAttribute("autocomplete", "off");
-      term.textarea.setAttribute("autocorrect", "off");
-      term.textarea.setAttribute("autocapitalize", "off");
-      term.textarea.setAttribute("spellcheck", "false");
-    }
     const disposeInputFix = attachMacWebKitShiftInputFix(term);
     loadWebglAddon(term);
 
@@ -111,6 +97,7 @@ export function TerminalView({
     };
 
     const writer = createSmartWriter(term);
+    const disposeMacWebKitGuard = attachMacWebKitTerminalGuard({ term, container, writer });
 
     const terminalGeneration = onRegisterRef.current(writer.write);
 
@@ -146,13 +133,6 @@ export function TerminalView({
     const handlePointerDown = (e: PointerEvent) => {
       if (e.button === 0) {
         focusTerminal();
-        writer.setSelectionPaused(true);
-      }
-    };
-    // pointerup 挂在 document 上，拖出终端区域外松手也能正确恢复
-    const handlePointerUp = (e: PointerEvent) => {
-      if (e.button === 0) {
-        writer.setSelectionPaused(false);
       }
     };
     const handleVisibilityChange = () => {
@@ -160,13 +140,11 @@ export function TerminalView({
       window.requestAnimationFrame(() => {
         const s = safeFit(fitAddon, term);
         if (s) notifyResize(s.cols, s.rows);
-        term.refresh(0, term.rows - 1);
         term.focus();
       });
     };
 
     container.addEventListener("pointerdown", handlePointerDown as EventListener);
-    document.addEventListener("pointerup", handlePointerUp as EventListener);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -186,16 +164,15 @@ export function TerminalView({
       } catch {
         /* ignore */
       }
-      container.classList.remove("xterm-macos-ime-guard");
       onRegisterRef.current(null);
       fitAddonRef.current = null;
+      disposeMacWebKitGuard();
       disposeInputFix();
       disposeSmartCopy();
       disposeOnData.dispose();
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeObserver.disconnect();
       container.removeEventListener("pointerdown", handlePointerDown as EventListener);
-      document.removeEventListener("pointerup", handlePointerUp as EventListener);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       terminalRef.current = null;
       term.dispose();
@@ -208,7 +185,6 @@ export function TerminalView({
       if (!fitAddonRef.current || !terminalRef.current) return;
       const s = safeFit(fitAddonRef.current, terminalRef.current);
       if (s) notifyResize(s.cols, s.rows);
-      terminalRef.current.refresh(0, terminalRef.current.rows - 1);
       terminalRef.current.focus();
     });
   }, [isActive, notifyResize]);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -15,6 +15,7 @@ import {
   applyTerminalFontFamily,
 } from "./terminalShared";
 import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import { IS_MAC_WEBKIT } from "../platform";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -88,7 +89,10 @@ export function TerminalView({
     // 查询。textarea 默认在屏幕外（left: -9999em），但 macOS 输入法仍可能
     // 主动定位它。配合 src/styles/xterm.css 中 .xterm-rows 的 pointer-events: none
     // 一起切断 IME 查询风暴的两条入口。详见 knowledge/xterm/rendering-and-selection-lag.md §7。
-    if (term.textarea) {
+    if (IS_MAC_WEBKIT) {
+      container.classList.add("xterm-macos-ime-guard");
+    }
+    if (IS_MAC_WEBKIT && term.textarea) {
       term.textarea.setAttribute("autocomplete", "off");
       term.textarea.setAttribute("autocorrect", "off");
       term.textarea.setAttribute("autocapitalize", "off");
@@ -118,7 +122,7 @@ export function TerminalView({
     const processedSpans = new WeakSet<Element>();
     const ASCII_ONLY = /^[\x20-\x7E]*$/;
     let rowSanitizer: MutationObserver | null = null;
-    if (rowsEl) {
+    if (IS_MAC_WEBKIT && rowsEl) {
       rowSanitizer = new MutationObserver((mutations) => {
         for (const m of mutations) {
           if (m.type !== "childList") continue;
@@ -226,6 +230,7 @@ export function TerminalView({
         /* ignore */
       }
       rowSanitizer?.disconnect();
+      container.classList.remove("xterm-macos-ime-guard");
       onRegisterRef.current(null);
       fitAddonRef.current = null;
       disposeInputFix();

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -83,8 +83,62 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
+    // 关掉 macOS 在 helper textarea 上的拼写检查 / 自动纠正 / 文本预测——
+    // 这些行为会主动触发 NSTextInputClient 的 characterIndexForPointAsync
+    // 查询。textarea 默认在屏幕外（left: -9999em），但 macOS 输入法仍可能
+    // 主动定位它。配合 src/styles/xterm.css 中 .xterm-rows 的 pointer-events: none
+    // 一起切断 IME 查询风暴的两条入口。详见 knowledge/xterm/rendering-and-selection-lag.md §7。
+    if (term.textarea) {
+      term.textarea.setAttribute("autocomplete", "off");
+      term.textarea.setAttribute("autocorrect", "off");
+      term.textarea.setAttribute("autocapitalize", "off");
+      term.textarea.setAttribute("spellcheck", "false");
+    }
     const disposeInputFix = attachMacWebKitShiftInputFix(term);
     loadWebglAddon(term);
+
+    // 拦截 xterm 每帧 _rowFactory.createRow → row div replaceChildren 写入的 span：
+    // 含非 ASCII（emoji / box drawing）的 textContent 立刻替换为单字符 "x"。
+    //
+    // styles/xterm.css 中 .xterm-rows pointer-events: none 拦掉了 macOS
+    // characterIndexForPointAsync 的 hit-test 入口，但 WebKit 的 canonicalPosition
+    // 仍会在 RenderTree 里向前/向后游走候选 Position，进入 row span 内的 RenderText
+    // ——这一步不看 pointer-events。实测把 IME 路径从 99.7% 压到 ~20%，剩下的就是
+    // canonicalPosition × PositionIterator::decrement/increment × ICU TextBreakIterator
+    // 在每个 RenderText 上做 emoji 簇判断 (__CFStringGetExtendedPictographicSequenceComponent)。
+    //
+    // 把非 ASCII 替换成单字符 ASCII 后：PositionIterator 仍游走 1500+ 次（这是 WebKit
+    // 内部行为，改不了），但每次 ICU setText 走 ASCII fast path 几乎免费。预期把 IME
+    // 路径再压到 <5%。row div 仍保留非零 boundingClientRect.width，xterm 的
+    // _alignRowWidth scaleX 校准不会触发除零；视觉上 row 子树本来就被 canvas 覆盖，
+    // 替换不影响显示。Cmd+C 复制走 attachSmartCopy → buffer.translateToString，不读 DOM。
+    //
+    // 详见 knowledge/xterm/rendering-and-selection-lag.md §7。
+    const rowsEl = container.querySelector(".xterm-rows");
+    const processedSpans = new WeakSet<Element>();
+    const ASCII_ONLY = /^[\x20-\x7E]*$/;
+    let rowSanitizer: MutationObserver | null = null;
+    if (rowsEl) {
+      rowSanitizer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          if (m.type !== "childList") continue;
+          for (const n of m.addedNodes) {
+            if (n.nodeType !== Node.ELEMENT_NODE) continue;
+            const el = n as Element;
+            if (el.tagName !== "SPAN") continue;
+            if (processedSpans.has(el)) continue;
+            const text = el.textContent;
+            if (!text || text.length <= 1 || ASCII_ONLY.test(text)) {
+              processedSpans.add(el);
+              continue;
+            }
+            el.textContent = "x";
+            processedSpans.add(el);
+          }
+        }
+      });
+      rowSanitizer.observe(rowsEl, { childList: true, subtree: true });
+    }
 
     const size = safeFit(fitAddon, term);
     if (size) notifyResize(size.cols, size.rows);
@@ -171,6 +225,7 @@ export function TerminalView({
       } catch {
         /* ignore */
       }
+      rowSanitizer?.disconnect();
       onRegisterRef.current(null);
       fitAddonRef.current = null;
       disposeInputFix();

--- a/src/components/terminalInputFix.ts
+++ b/src/components/terminalInputFix.ts
@@ -1,17 +1,7 @@
 import type { Terminal } from "@xterm/xterm";
-import { APP_PLATFORM } from "../platform";
+import { IS_MAC_WEBKIT, IS_OTHER_WEBKIT } from "../platform";
 
 type TerminalWithInput = Pick<Terminal, "input" | "textarea">;
-
-function isMacWebKit(): boolean {
-  if (APP_PLATFORM !== "macos" || typeof navigator === "undefined") return false;
-  return navigator.userAgent.includes("AppleWebKit");
-}
-
-function isLinuxWebKit(): boolean {
-  if (APP_PLATFORM !== "other" || typeof navigator === "undefined") return false;
-  return navigator.userAgent.includes("AppleWebKit");
-}
 
 function getPrintableSymbolInput(data: string | null): string | null {
   if (data === null || data.length === 0) return null;
@@ -25,7 +15,7 @@ function isSymbolInputType(inputType: string): boolean {
 }
 
 export function attachMacWebKitShiftInputFix(term: TerminalWithInput): () => void {
-  if (!isMacWebKit() || !term.textarea) return () => {};
+  if (!IS_MAC_WEBKIT || !term.textarea) return () => {};
 
   const textarea = term.textarea;
   let keydownHandledByXterm: string | null = null;
@@ -70,7 +60,7 @@ export function attachLinuxIMEFix(
   term: Terminal,
   onDataCallback: (data: string) => void,
 ): { dispose: () => void } {
-  if (!isLinuxWebKit() || !term.textarea) {
+  if (!IS_OTHER_WEBKIT || !term.textarea) {
     const disposable = term.onData(onDataCallback);
     return { dispose: () => disposable.dispose() };
   }

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -3,6 +3,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { IS_MAC_WEBKIT } from "../platform";
+import { publishTerminalSelectionActive } from "../terminalSelection";
 
 // ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -70,6 +71,7 @@ interface TerminalSelectionGuardOptions {
 }
 
 const macWebKitInertCounts = new WeakMap<HTMLElement, number>();
+let macWebKitSelectionGuardCount = 0;
 
 function setMacWebKitTextareaAttrs(term: Terminal): void {
   if (!term.textarea) return;
@@ -133,6 +135,14 @@ export function attachMacWebKitTerminalGuard({
   const inertedNodes = new Set<HTMLElement>();
   let pointerSelecting = false;
   let terminalHasSelection = term.hasSelection();
+  let guardSelectionActive = false;
+
+  const setGuardSelectionActive = (active: boolean) => {
+    if (guardSelectionActive === active) return;
+    guardSelectionActive = active;
+    macWebKitSelectionGuardCount += active ? 1 : -1;
+    publishTerminalSelectionActive(macWebKitSelectionGuardCount > 0);
+  };
 
   const restoreSiblings = () => {
     for (const node of inertedNodes) {
@@ -142,7 +152,9 @@ export function attachMacWebKitTerminalGuard({
   };
 
   const syncSiblings = () => {
-    if (pointerSelecting || terminalHasSelection) {
+    const active = pointerSelecting || terminalHasSelection;
+    setGuardSelectionActive(active);
+    if (active) {
       inertTerminalBranchSiblings(container, inertedNodes);
     } else {
       restoreSiblings();
@@ -211,6 +223,7 @@ export function attachMacWebKitTerminalGuard({
     document.removeEventListener("pointerdown", handleDocumentPointerDown, true);
     document.removeEventListener("keydown", handleKeyDown, true);
     writer?.setSelectionPaused(false);
+    setGuardSelectionActive(false);
     restoreSiblings();
   };
 }

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -2,6 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { IS_MAC_WEBKIT } from "../platform";
 
 // ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,158 @@ export interface SmartWriter {
   write: (data: string, callback?: () => void) => void;
   drainPending: () => void;
   setSelectionPaused: (paused: boolean) => void;
+}
+
+interface TerminalSelectionGuardOptions {
+  term: Terminal;
+  container: HTMLElement;
+  writer?: Pick<SmartWriter, "setSelectionPaused">;
+}
+
+const macWebKitInertCounts = new WeakMap<HTMLElement, number>();
+
+function setMacWebKitTextareaAttrs(term: Terminal): void {
+  if (!term.textarea) return;
+  term.textarea.setAttribute("autocomplete", "off");
+  term.textarea.setAttribute("autocorrect", "off");
+  term.textarea.setAttribute("autocapitalize", "off");
+  term.textarea.setAttribute("spellcheck", "false");
+}
+
+function acquireInert(node: HTMLElement, ownedNodes: Set<HTMLElement>): void {
+  if (ownedNodes.has(node)) return;
+  const currentCount = macWebKitInertCounts.get(node);
+  if (currentCount !== undefined) {
+    macWebKitInertCounts.set(node, currentCount + 1);
+    ownedNodes.add(node);
+    return;
+  }
+  if (node.inert) return;
+  node.inert = true;
+  macWebKitInertCounts.set(node, 1);
+  ownedNodes.add(node);
+}
+
+function releaseInert(node: HTMLElement): void {
+  const currentCount = macWebKitInertCounts.get(node);
+  if (currentCount === undefined) return;
+  if (currentCount > 1) {
+    macWebKitInertCounts.set(node, currentCount - 1);
+    return;
+  }
+  macWebKitInertCounts.delete(node);
+  node.inert = false;
+}
+
+function inertTerminalBranchSiblings(container: HTMLElement, ownedNodes: Set<HTMLElement>): void {
+  let current: HTMLElement | null = container;
+  while (current && current !== document.body) {
+    const parent: HTMLElement | null = current.parentElement;
+    if (!parent) break;
+    for (const child of Array.from(parent.children)) {
+      if (child === current || !(child instanceof HTMLElement)) continue;
+      acquireInert(child, ownedNodes);
+    }
+    current = parent;
+  }
+}
+
+// WKWebView can service macOS NSTextInputClient hit-test queries against large
+// app DOM subtrees while an xterm selection exists. Keep those sibling branches
+// out of hit-testing during terminal selection without inerting the terminal path.
+export function attachMacWebKitTerminalGuard({
+  term,
+  container,
+  writer,
+}: TerminalSelectionGuardOptions): () => void {
+  if (!IS_MAC_WEBKIT) return () => {};
+
+  container.classList.add("xterm-macos-ime-guard");
+  setMacWebKitTextareaAttrs(term);
+
+  const inertedNodes = new Set<HTMLElement>();
+  let pointerSelecting = false;
+  let terminalHasSelection = term.hasSelection();
+
+  const restoreSiblings = () => {
+    for (const node of inertedNodes) {
+      releaseInert(node);
+    }
+    inertedNodes.clear();
+  };
+
+  const syncSiblings = () => {
+    if (pointerSelecting || terminalHasSelection) {
+      inertTerminalBranchSiblings(container, inertedNodes);
+    } else {
+      restoreSiblings();
+    }
+  };
+
+  const handlePointerDown = (e: PointerEvent) => {
+    if (e.button !== 0) return;
+    term.focus();
+    pointerSelecting = true;
+    writer?.setSelectionPaused(true);
+    syncSiblings();
+  };
+
+  const handlePointerUp = (e: PointerEvent) => {
+    if (e.button !== 0) return;
+    pointerSelecting = false;
+    writer?.setSelectionPaused(false);
+    terminalHasSelection = term.hasSelection();
+    syncSiblings();
+  };
+
+  const handlePointerCancel = () => {
+    pointerSelecting = false;
+    writer?.setSelectionPaused(false);
+    terminalHasSelection = term.hasSelection();
+    syncSiblings();
+  };
+
+  const handleDocumentPointerDown = (e: PointerEvent) => {
+    const target = e.target;
+    if (!terminalHasSelection || (target instanceof Node && container.contains(target))) return;
+    pointerSelecting = false;
+    terminalHasSelection = false;
+    writer?.setSelectionPaused(false);
+    term.clearSelection();
+    restoreSiblings();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== "Escape" || !terminalHasSelection) return;
+    pointerSelecting = false;
+    terminalHasSelection = false;
+    writer?.setSelectionPaused(false);
+    term.clearSelection();
+    restoreSiblings();
+  };
+
+  const selectionDisposable = term.onSelectionChange(() => {
+    terminalHasSelection = term.hasSelection();
+    syncSiblings();
+  });
+
+  container.addEventListener("pointerdown", handlePointerDown);
+  document.addEventListener("pointerup", handlePointerUp);
+  document.addEventListener("pointercancel", handlePointerCancel);
+  document.addEventListener("pointerdown", handleDocumentPointerDown, true);
+  document.addEventListener("keydown", handleKeyDown, true);
+
+  return () => {
+    container.classList.remove("xterm-macos-ime-guard");
+    selectionDisposable.dispose();
+    container.removeEventListener("pointerdown", handlePointerDown);
+    document.removeEventListener("pointerup", handlePointerUp);
+    document.removeEventListener("pointercancel", handlePointerCancel);
+    document.removeEventListener("pointerdown", handleDocumentPointerDown, true);
+    document.removeEventListener("keydown", handleKeyDown, true);
+    writer?.setSelectionPaused(false);
+    restoreSiblings();
+  };
 }
 
 /**
@@ -172,10 +325,12 @@ export function loadWebglAddon(term: Terminal): void {
   try {
     const webglAddon = new WebglAddon();
     webglAddon.onContextLoss(() => {
+      console.warn("[terminal] WebGL context lost; falling back to xterm DOM renderer");
       webglAddon.dispose();
     });
     term.loadAddon(webglAddon);
-  } catch {
+  } catch (err) {
+    console.warn("[terminal] WebGL addon unavailable; using xterm DOM renderer", err);
     /* 不支持 WebGL 时降级，不影响功能 */
   }
 }

--- a/src/hooks/useTerminalSelectionActive.ts
+++ b/src/hooks/useTerminalSelectionActive.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import {
+  getTerminalSelectionActive,
+  TERMINAL_SELECTION_ACTIVE_EVENT,
+} from "../terminalSelection";
+
+export function useTerminalSelectionActive(): boolean {
+  const [active, setActive] = useState(getTerminalSelectionActive);
+
+  useEffect(() => {
+    const handleSelectionActive = (event: Event) => {
+      setActive((event as CustomEvent<boolean>).detail === true);
+    };
+
+    window.addEventListener(TERMINAL_SELECTION_ACTIVE_EVENT, handleSelectionActive);
+    return () => {
+      window.removeEventListener(TERMINAL_SELECTION_ACTIVE_EVENT, handleSelectionActive);
+    };
+  }, []);
+
+  return active;
+}

--- a/src/hooks/useUsageSnapshot.ts
+++ b/src/hooks/useUsageSnapshot.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef, useState } from "react";
 import { ENABLE_USAGE_INSIGHTS } from "../platform";
 import type { UsageSnapshot } from "../types";
+import { useTerminalSelectionActive } from "./useTerminalSelectionActive";
 
 // Module-level cache — shared across all hook instances in the same process
 let cachedSnapshot: UsageSnapshot | null = null;
@@ -31,6 +32,8 @@ export function useUsageSnapshot(active: boolean) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
+  const terminalSelectionActive = useTerminalSelectionActive();
+  const effectiveActive = active && !terminalSelectionActive;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -40,7 +43,7 @@ export function useUsageSnapshot(active: boolean) {
   }, []);
 
   useEffect(() => {
-    if (!active || !ENABLE_USAGE_INSIGHTS) return;
+    if (!effectiveActive || !ENABLE_USAGE_INSIGHTS) return;
 
     const load = async () => {
       const now = Date.now();
@@ -68,7 +71,7 @@ export function useUsageSnapshot(active: boolean) {
     load();
     const interval = setInterval(load, 60_000);
     return () => clearInterval(interval);
-  }, [active]);
+  }, [effectiveActive]);
 
   return { snapshot, loading, error };
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -23,3 +23,10 @@ export function detectAppPlatform(currentNavigator: PlatformNavigator | undefine
 
 export const APP_PLATFORM = detectAppPlatform();
 export const ENABLE_USAGE_INSIGHTS = APP_PLATFORM !== "windows";
+
+export function isAppleWebKit(currentNavigator: PlatformNavigator | undefined = globalThis.navigator): boolean {
+  return currentNavigator?.userAgent.includes("AppleWebKit") ?? false;
+}
+
+export const IS_MAC_WEBKIT = APP_PLATFORM === "macos" && isAppleWebKit();
+export const IS_OTHER_WEBKIT = APP_PLATFORM === "other" && isAppleWebKit();

--- a/src/styles/xterm.css
+++ b/src/styles/xterm.css
@@ -28,7 +28,7 @@
  * 不要因为"row 也许哪天需要响应点击"删掉这条规则——xterm 设计上
  * row div 是辅助显示层，所有交互都在 .xterm-screen 上做 hit-test。
  */
-.xterm-rows,
-.xterm-rows * {
+.xterm-macos-ime-guard .xterm-rows,
+.xterm-macos-ime-guard .xterm-rows * {
   pointer-events: none;
 }

--- a/src/styles/xterm.css
+++ b/src/styles/xterm.css
@@ -1,9 +1,9 @@
 /*
  * xterm 的 .xterm-rows 子树对 macOS NSTextInputClient 不可见。
  *
- * 背景：xterm v6 即使在 WebGL 模式下，_rowFactory.createRow() 仍然往每个
- * row div 内 replaceChildren(...spans) 写入完整字符 textContent，目的是
- * 让浏览器原生 selection / copy 能工作。
+ * 背景：xterm v6 在 WebGL renderer 正常启用后会同步移除 DomRenderer 的
+ * .xterm-rows；因此这条规则通常不会 match。它保留为 DOM renderer fallback：
+ * WebGL 不可用或 context loss 后，.xterm-rows 会重新出现。
  *
  * 但 nezha 不依赖这条路径——
  *   - xterm 自己的拖选基于 mouseService.getCoords(event, screenElement)，
@@ -11,14 +11,14 @@
  *   - 复制走 attachSmartCopy → terminal.buffer.translateToString，
  *     直接从 xterm core buffer 取字符，不读 DOM。
  *
- * 长会话累积大量 row span 后，macOS NSTextInputClient 的
- * characterIndexForPointAsync（IME 候选词位置预测 / selection 状态轮询）
- * 会让 WebKit 走 LocalFrame::rangeForPoint → canonicalPosition →
- * PositionIterator::increment × 1500+ 次，每个 span 创建 ICU
- * TextBreakIterator 做 emoji grapheme 簇判断 → 主线程 100%，前端卡死。
+ * macOS NSTextInputClient 的 characterIndexForPointAsync（IME 候选词位置预测 /
+ * selection 状态轮询）会让 WebKit 走 LocalFrame::rangeForPoint →
+ * canonicalPosition → PositionIterator。2026-05-22 sample 证明当前风暴主要
+ * 游走到 Nezha 自己的含 <img> / emoji 子树；真正的主防线在
+ * terminalShared.ts::attachMacWebKitTerminalGuard 的 inert 逻辑。
  *
- * 实测（pid 335 sample，5s/3416 主线程样本）：99.7% 卡在该调用栈；
- * reload 后 0 次调用立刻恢复。详见 knowledge/xterm/rendering-and-selection-lag.md §7。
+ * 这条 CSS 只负责 WebGL fallback 时缩小 .xterm-rows 的 hit-test 面。
+ * 详见 knowledge/xterm/rendering-and-selection-lag.md §7。
  *
  * pointer-events: none 让 WebKit hit-test 跳过这棵子树，
  * NSTextInput 的 characterIndexForPoint 命中外层 .xterm-screen / canvas，

--- a/src/styles/xterm.css
+++ b/src/styles/xterm.css
@@ -1,0 +1,34 @@
+/*
+ * xterm 的 .xterm-rows 子树对 macOS NSTextInputClient 不可见。
+ *
+ * 背景：xterm v6 即使在 WebGL 模式下，_rowFactory.createRow() 仍然往每个
+ * row div 内 replaceChildren(...spans) 写入完整字符 textContent，目的是
+ * 让浏览器原生 selection / copy 能工作。
+ *
+ * 但 nezha 不依赖这条路径——
+ *   - xterm 自己的拖选基于 mouseService.getCoords(event, screenElement)，
+ *     只用 boundingRect 坐标，不读 row DOM textContent；
+ *   - 复制走 attachSmartCopy → terminal.buffer.translateToString，
+ *     直接从 xterm core buffer 取字符，不读 DOM。
+ *
+ * 长会话累积大量 row span 后，macOS NSTextInputClient 的
+ * characterIndexForPointAsync（IME 候选词位置预测 / selection 状态轮询）
+ * 会让 WebKit 走 LocalFrame::rangeForPoint → canonicalPosition →
+ * PositionIterator::increment × 1500+ 次，每个 span 创建 ICU
+ * TextBreakIterator 做 emoji grapheme 簇判断 → 主线程 100%，前端卡死。
+ *
+ * 实测（pid 335 sample，5s/3416 主线程样本）：99.7% 卡在该调用栈；
+ * reload 后 0 次调用立刻恢复。详见 knowledge/xterm/rendering-and-selection-lag.md §7。
+ *
+ * pointer-events: none 让 WebKit hit-test 跳过这棵子树，
+ * NSTextInput 的 characterIndexForPoint 命中外层 .xterm-screen / canvas，
+ * 不再触发 RenderText 全树遍历。xterm 自己的 mousedown 挂在 .xterm 根容器
+ * 上，事件正常冒泡，selection / scroll / focus 全部不受影响。
+ *
+ * 不要因为"row 也许哪天需要响应点击"删掉这条规则——xterm 设计上
+ * row div 是辅助显示层，所有交互都在 .xterm-screen 上做 hit-test。
+ */
+.xterm-rows,
+.xterm-rows * {
+  pointer-events: none;
+}

--- a/src/terminalSelection.ts
+++ b/src/terminalSelection.ts
@@ -1,0 +1,19 @@
+export const TERMINAL_SELECTION_ACTIVE_EVENT = "nezha-terminal-selection-active";
+
+declare global {
+  interface Window {
+    __nezhaTerminalSelectionActive?: boolean;
+  }
+}
+
+export function getTerminalSelectionActive(): boolean {
+  return typeof window !== "undefined" && window.__nezhaTerminalSelectionActive === true;
+}
+
+export function publishTerminalSelectionActive(active: boolean): void {
+  if (typeof window === "undefined") return;
+  window.__nezhaTerminalSelectionActive = active;
+  window.dispatchEvent(
+    new CustomEvent<boolean>(TERMINAL_SELECTION_ACTIVE_EVENT, { detail: active }),
+  );
+}


### PR DESCRIPTION
Block WebKit hit-test into .xterm-rows via pointer-events: none and sanitize non-ASCII row span textContent through a MutationObserver to keep ICU emoji grapheme iteration off the main thread. Disable spell check / autocorrect on the helper textarea to cut the other IME query entrypoint. Drops CharacterIndexForPointAsync main-thread share from 99.7% to <5% on long sessions. See knowledge/xterm/rendering-and- selection-lag.md §7.