### PR TITLE
fix: file viewer path bar background now follows theme

### DIFF
--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -408,13 +408,13 @@ function FilePreviewPane({
           alignItems: "center",
           padding: "0 12px",
           borderTop: "1px solid var(--border-dim)",
-          background: "var(--accent)",
+          background: "var(--bg-subtle)",
           flexShrink: 0,
           gap: 8,
         }}
       >
         <span
-          style={{ fontSize: 11, color: "var(--inverse-muted)", fontFamily: "var(--font-mono)" }}
+          style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}
         >
           {filePath}
         </span>
@@ -423,7 +423,7 @@ function FilePreviewPane({
             style={{
               marginLeft: "auto",
               fontSize: 11,
-              color: saveStatus === "error" ? "var(--danger-fg)" : "var(--inverse-muted)",
+              color: saveStatus === "error" ? "var(--danger-fg)" : "var(--text-muted)",
               fontFamily: "var(--font-mono)",
             }}
           >


### PR DESCRIPTION
## 问题现象
进入「设置 — 外观」切换主题后，文件查看器（FileViewer）底部显示文件绝对路径的状态栏背景色看起来始终不变（尤其在浅色 ↔ 深色之间切换时）。

## 根因
`src/components/FilePreviewPane`（`FileViewer.tsx`）底部栏：
- 背景使用 `var(--accent)`（强调色）。`--accent` 在浅色主题是 `#5d7cff`、深色是 `#7f9aff`，二者都是相近的蓝色，因此切换浅/深主题时背景几乎看不出变化；`--accent` 本意用于文本/按钮强调，不适合作大面积背景。
- 文字色 `var(--inverse-muted)` 仅在 `:root`（浅色）定义，`html.dark` / `html.eyecare` 均未重定义，所以文字色也不随主题变化。

其他面板底部栏（GitChanges / GitHistory / RunningView）均不设强调色背景、直接继承面板表面色，天然跟随主题——此路径栏是唯一异类。

## 改动
将该底部栏改用三个主题均已定义的表面/文字色 token，与其他面板底部栏保持一致：
- 背景：`var(--accent)` → `var(--bg-subtle)`
- 文字：`var(--inverse-muted)` → `var(--text-muted)`（error 状态仍为 `var(--danger-fg)`）

`--inverse-muted` 仍被 Toast 组件使用，故保留其定义。

## 验证
- `eslint` 与 `tsc --noEmit` 均通过。
- 本地切换 浅色 / 深色 / 护眼 三主题，路径栏背景与文字颜色均明显随主题变化，对比度可读，观感与其他面板底部栏一致。