### PR TITLE
fix: 文件树点击文件夹偶发自动折叠的双击效果 (#194)

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -216,6 +216,11 @@ export function FileExplorer({
 
   const handleToggle = useCallback(
     (dirPath: string) => {
+      // Invalidate any in-flight auto-refresh: it captured a snapshot before this
+      // toggle and would otherwise apply that stale tree, collapsing the folder the
+      // user just expanded (issue #194).
+      refreshIdRef.current += 1;
+
       const current = findNode(nodesRef.current, dirPath);
       const shouldExpand = !current?.expanded;
 


### PR DESCRIPTION
Fixes #194

## 问题现象
文件列表视图中点击折叠的文件夹，会先正常展开、随即自动折叠，呈现"双击/连点"效果。非 100% 必现，但一旦出现会高频复发（Windows 11，v0.3.7）。

## 根因：自动刷新与展开操作的竞态
`FileExplorer` 每 `AUTO_REFRESH_MS`（2.5s）调用一次 `refresh()`。`refresh()` 在 await 前捕获 `nodesRef.current` 快照，再异步 `loadTreeNodes()` 重建整棵树。

时序：
1. `refresh()` 用「文件夹仍折叠」的快照启动异步加载；
2. 用户在加载途中点击文件夹，`handleToggle` 将 `expanded` 置为 `true`；
3. `refresh()` 完成，返回的是基于旧快照算出的树（该文件夹仍 `expanded=false`），其 `setNodes` 覆盖了用户刚设的展开态 → 文件夹瞬间折叠。

已有的 `refreshIdRef` 守卫只能让"后一个 refresh 作废前一个 refresh"，无法感知期间发生的用户 toggle，因此陈旧结果照样落地。

## 修复
复用既有的 `refreshIdRef` 作废机制：在 `handleToggle` 开头 `refreshIdRef.current += 1`，让任何在途的 refresh 在完成时因 id 不匹配而直接 return、不再 `setNodes`。下一次周期 refresh 读到的已是展开后的树，`loadTreeNodes` 通过 `previous.expanded` 正确保留展开态。

改动仅一处、低风险，不影响新建/重命名/删除（它们各自 `await refresh()` 自行重同步）。

## 验证
- `eslint` 与 `tsc --noEmit` 均通过。
- 本地将 `AUTO_REFRESH_MS` 临时调小后反复点击折叠文件夹，确认展开后不再自动折叠；新建/重命名/删除回归正常。