### PR TITLE
fix(git): resolve commit message generation issue on Windows

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -181,27 +182,78 @@ fn apply_login_shell_env(cmd: &mut Command) {
     }
 }
 
+fn run_command_with_prompt_stdin(
+    mut cmd: Command,
+    agent: &str,
+    prompt: &str,
+) -> Result<Output, String> {
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to run {agent}: {e}"))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("Failed to open {agent} stdin"))?;
+        if let Err(e) = stdin.write_all(prompt.as_bytes()) {
+            // If the child exits early (for example because the CLI is not authenticated),
+            // still wait for its output so the caller can surface the real CLI error.
+            if e.kind() != ErrorKind::BrokenPipe {
+                return Err(format!("Failed to write prompt to {agent} stdin: {e}"));
+            }
+        }
+    }
+
+    child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for {agent}: {e}"))
+}
+
+fn configure_agent_command_base(cmd: &mut Command, project_path: &str) {
+    crate::subprocess::configure_background_command(cmd);
+    cmd.current_dir(project_path);
+    apply_login_shell_env(cmd);
+}
+
 fn run_agent_commit_message_command(
     agent: &str,
     project_path: &str,
     prompt: &str,
 ) -> Result<Output, String> {
     let launch = crate::app_settings::get_agent_launch_spec(agent);
-    let mut cmd = Command::new(&launch.program);
-    crate::subprocess::configure_background_command(&mut cmd);
+
     if agent == "codex" {
-        cmd.args(["exec", prompt]);
-    } else {
-        cmd.args(["-p", prompt, "--output-format", "text"]);
+        let mut cmd = Command::new(&launch.program);
+        configure_agent_command_base(&mut cmd, project_path);
+        for (key, value) in &launch.extra_env {
+            cmd.env(key, value);
+        }
+        // Avoid Windows command-line length limits by passing the full prompt over stdin.
+        // Current Codex CLI supports `codex exec -` to read the task prompt from stdin.
+        cmd.args(["exec", "-"]);
+        return run_command_with_prompt_stdin(cmd, agent, prompt);
     }
-    cmd.current_dir(project_path);
-    cmd.stdin(Stdio::null());
-    apply_login_shell_env(&mut cmd);
+
+    let mut cmd = Command::new(&launch.program);
+    configure_agent_command_base(&mut cmd, project_path);
     for (key, value) in &launch.extra_env {
         cmd.env(key, value);
     }
-    cmd.output()
-        .map_err(|e| format!("Failed to run {agent}: {e}"))
+    // Claude Code supports piped stdin in print mode. Keep only a short driver prompt
+    // on the command line and send the large diff/request through stdin so Windows never
+    // sees the diff as a command-line argument or shell-redirection file name.
+    cmd.args([
+        "-p",
+        "Read the complete commit-message request from standard input, follow it exactly, and output only the commit message.",
+        "--output-format",
+        "text",
+    ]);
+    run_command_with_prompt_stdin(cmd, agent, prompt)
 }
 
 fn create_empty_temp_file() -> Result<PathBuf, String> {
@@ -222,7 +274,7 @@ pub async fn generate_commit_message(project_path: String) -> Result<String, Str
         return Err("No staged changes to generate a commit message for.".to_string());
     }
 
-    // Truncate diff if too large to avoid CLI arg limits
+    // Truncate diff if too large to keep agent context manageable
     let diff = if diff.len() > 50_000 {
         format!("{}...(diff truncated)", &diff[..50_000])
     } else {
@@ -240,15 +292,15 @@ pub async fn generate_commit_message(project_path: String) -> Result<String, Str
         commit_prompt, diff
     );
 
-    // 4. Run agent in non-interactive exec mode with 15 second timeout
+    // 4. Run agent in non-interactive exec mode with 2 minute timeout
     let output = tokio::time::timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(120),
         tokio::task::spawn_blocking(move || {
             run_agent_commit_message_command(&agent, &project_path, &full_prompt)
         }),
     )
     .await
-    .map_err(|_| "生成提交信息超时（15秒）".to_string())?
+    .map_err(|_| "生成提交信息超时（2分钟）".to_string())?
     .map_err(|e| format!("生成提交信息线程错误: {}", e))??;
 
     if !output.status.success() {
@@ -1007,34 +1059,60 @@ pub async fn git_show_file_diff(
 #[tauri::command]
 pub async fn git_push(project_path: String, branch: Option<String>) -> Result<String, String> {
     let mut args = vec!["push".to_string()];
+    let push_branch = branch
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            // Resolve current branch name for the success message
+            String::new()
+        });
     if let Some(ref b) = branch.filter(|s| !s.is_empty()) {
         args.push("origin".to_string());
         args.push(b.clone());
     }
     let output = run_git(&project_path, &args)?;
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     if !output.status.success() {
-        return Err(combined);
+        let combined = format!("{}{}", stdout, stderr);
+        return Err(combined.trim().to_string());
     }
-    Ok(combined.trim().to_string())
+
+    // Resolve branch name for the success message
+    let branch_display = if !push_branch.is_empty() {
+        push_branch
+    } else {
+        let branch_out = run_git(&project_path, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        match branch_out {
+            Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .to_string(),
+            _ => "origin".to_string(),
+        }
+    };
+
+    Ok(branch_display)
 }
 
 #[tauri::command]
 pub async fn git_pull(project_path: String) -> Result<String, String> {
     let output = run_git(&project_path, &["pull"])?;
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     if !output.status.success() {
-        return Err(combined);
+        let combined = format!("{}{}", stdout, stderr);
+        return Err(combined.trim().to_string());
     }
-    Ok(combined.trim().to_string())
+
+    // Resolve current branch name for the success message
+    let branch_display = match run_git(&project_path, &["rev-parse", "--abbrev-ref", "HEAD"]) {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .trim()
+            .to_string(),
+        _ => String::new(),
+    };
+
+    Ok(branch_display)
 }
 
 #[derive(serde::Serialize)]


### PR DESCRIPTION
- Use stdin to pass prompt to agents, avoiding Windows command-line length limits
- Increase timeout from 15s to 2 minutes for commit message generation
- Improve git_push/git_pull to return branch name for better UX