### PR TITLE
fix(git): pipe commit prompt via stdin and safe UTF-8 truncation

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -189,19 +190,64 @@ fn run_agent_commit_message_command(
     let launch = crate::app_settings::get_agent_launch_spec(agent);
     let mut cmd = Command::new(&launch.program);
     crate::subprocess::configure_background_command(&mut cmd);
+
     if agent == "codex" {
         cmd.args(["exec", prompt]);
+        cmd.stdin(Stdio::null());
     } else {
-        cmd.args(["-p", prompt, "--output-format", "text"]);
+        cmd.args([
+            "-p",
+            "Generate a commit message from the instructions and git diff provided on stdin. Output only the commit message, nothing else.",
+            "--output-format",
+            "text",
+        ]);
+        cmd.stdin(Stdio::piped());
     }
+
     cmd.current_dir(project_path);
-    cmd.stdin(Stdio::null());
     apply_login_shell_env(&mut cmd);
     for (key, value) in &launch.extra_env {
         cmd.env(key, value);
     }
-    cmd.output()
-        .map_err(|e| format!("Failed to run {agent}: {e}"))
+
+    if agent == "codex" {
+        return cmd
+            .output()
+            .map_err(|e| format!("Failed to run {agent}: {e}"));
+    }
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to run {agent}: {e}"))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("Failed to open {agent} stdin"))?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .map_err(|e| format!("Failed to write prompt to {agent} stdin: {e}"))?;
+    }
+
+    child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for {agent}: {e}"))
+}
+
+fn truncate_utf8(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    format!("{}...(diff truncated)", &s[..end])
 }
 
 fn create_empty_temp_file() -> Result<PathBuf, String> {
@@ -222,12 +268,8 @@ pub async fn generate_commit_message(project_path: String) -> Result<String, Str
         return Err("No staged changes to generate a commit message for.".to_string());
     }
 
-    // Truncate diff if too large to avoid CLI arg limits
-    let diff = if diff.len() > 50_000 {
-        format!("{}...(diff truncated)", &diff[..50_000])
-    } else {
-        diff
-    };
+    // Truncate diff safely at a UTF-8 boundary.
+    let diff = truncate_utf8(&diff, 50_000);
 
     // 2. Read project config for prompt and default agent
     let config = crate::config::read_project_config(project_path.clone())?;


### PR DESCRIPTION
Summary

  - Refactor run_agent_commit_message_command to pipe the
  full prompt via stdin for Claude Code, instead of passing
  it as a command-line argument (-p <prompt>)
  - Move stdin configuration into each agent branch: Codex
  continues using Stdio::null() and cmd.output(), Claude
  Code uses Stdio::piped() with spawn + write_all +
  wait_with_output
  - Add truncate_utf8() helper to safely truncate diff
  strings at a valid UTF-8 character boundary, replacing
  the raw byte slice &diff[..50_000] which panics on
  multi-byte characters
  - Replace cmd.output() with explicit spawn → stdin write
  → wait_with_output() lifecycle for the Claude Code path

  How it works

  Before: The full prompt (diff + instructions) was passed
  as a CLI argument to claude -p "<prompt>". On Windows,
  CreateProcess has a ~32K command-line length limit,
  causing os error 206 (filename too long) for large diffs.

  After: The command line only carries a fixed instruction
  string. The actual prompt is written to the child
  process's stdin pipe. Codex is unaffected — it still
  receives the prompt as a CLI argument.

  For UTF-8 safety, truncate_utf8() walks backward from the
  target byte offset using str::is_char_boundary() until
  it lands on a valid boundary, preventing a panic when
  truncating strings containing CJK or other multi-byte
  characters.

  Test plan

  - Verify generate_commit_message with a small staged diff
  returns a valid commit message from Claude Code
  - Verify generate_commit_message with a large staged diff
  (>50KB) does not panic and returns a truncated prompt
  result
  - Verify Codex agent path still passes prompt via CLI
  argument (cmd.args(["exec", prompt]))
  - Verify the Claude Code child process receives the
  prompt via stdin (not CLI args)
  - Verify truncated UTF-8 string ends at a valid character
  boundary for CJK-heavy diffs
  - Verify error handling: stdin write failure and process
  spawn failure both return descriptive error messages