### PR TITLE
fix(project): restore hiddenFromRail when opening or clicking a project

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+enablePreScripts: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-enablePreScripts: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -407,7 +407,7 @@ function App() {
     const path = selected as string;
     const existing = projects.find((p) => p.path === path);
     const project: Project = existing
-      ? { ...existing, lastOpenedAt: Date.now() }
+      ? { ...existing, lastOpenedAt: Date.now(), hiddenFromRail: false }
       : { id: `${Date.now()}`, name: deriveProjectName(path), path, lastOpenedAt: Date.now() };
     setProjects((prev) => {
       const next = [project, ...prev.filter((p) => p.path !== path)];
@@ -423,7 +423,7 @@ function App() {
   }
 
   function handleProjectClick(project: Project) {
-    const updated = { ...project, lastOpenedAt: Date.now() };
+    const updated = { ...project, lastOpenedAt: Date.now(), hiddenFromRail: false };
     setProjects((prev) => {
       const next = prev.map((p) => (p.id === project.id ? updated : p));
       persistProjects(next, showToast, formatSaveProjectsError);


### PR DESCRIPTION
## Problem

Closes #220

When a project was unpinned from the rail (`hiddenFromRail=true`) via the WelcomePage pin button, and the user later re-opened it — either through the file dialog or by clicking it in the WelcomePage — the project remained hidden from the ProjectRail despite becoming the active project.

**Root cause:** The `ae8444a` commit introduced the `hiddenFromRail` feature with a filter in `ProjectRail`:

```js
projects.filter((p) => !p.hiddenFromRail || p.id === activeProjectId)
```

The fallback `|| p.id === activeProjectId` was intended to keep the active project visible even when hidden, but `handleOpen` and `handleProjectClick` both spread the existing project object without resetting the flag, so `hiddenFromRail: true` was carried over into the new state.

## Fix

Reset `hiddenFromRail: false` in both entry points where a user explicitly opens a project:

- `handleOpen` — opened via the file-picker dialog
- `handleProjectClick` — clicked in the WelcomePage list

Any deliberate user action to open a project implies the intent to see it in the rail.

## Changes

- `src/App.tsx`: 2-line change, one in `handleOpen` and one in `handleProjectClick`