### PR TITLE
refactor(git): improve push/pull UX with toast notifications

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1022,34 +1022,45 @@ pub async fn git_show_file_diff(
 #[tauri::command]
 pub async fn git_push(project_path: String, branch: Option<String>) -> Result<String, String> {
     let mut args = vec!["push".to_string()];
-    if let Some(ref b) = branch.filter(|s| !s.is_empty()) {
+    let requested_branch = branch.clone().filter(|s| !s.is_empty());
+    if let Some(ref b) = requested_branch {
         args.push("origin".to_string());
         args.push(b.clone());
     }
     let output = run_git(&project_path, &args)?;
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     if !output.status.success() {
-        return Err(combined);
+        return Err(format!("{}{}", stdout, stderr).trim().to_string());
     }
-    Ok(combined.trim().to_string())
+
+    if let Some(branch) = requested_branch {
+        return Ok(branch);
+    }
+
+    let branch_out = run_git(&project_path, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    if !branch_out.status.success() {
+        return Ok(String::new());
+    }
+
+    Ok(String::from_utf8_lossy(&branch_out.stdout).trim().to_string())
 }
 
 #[tauri::command]
 pub async fn git_pull(project_path: String) -> Result<String, String> {
     let output = run_git(&project_path, &["pull"])?;
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     if !output.status.success() {
-        return Err(combined);
+        return Err(format!("{}{}", stdout, stderr).trim().to_string());
     }
-    Ok(combined.trim().to_string())
+
+    let branch_out = run_git(&project_path, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    if !branch_out.status.success() {
+        return Ok(String::new());
+    }
+
+    Ok(String::from_utf8_lossy(&branch_out.stdout).trim().to_string())
 }
 
 #[derive(serde::Serialize)]

--- a/src/components/GitChanges.tsx
+++ b/src/components/GitChanges.tsx
@@ -14,6 +14,7 @@ import { useCancellableInvoke } from "../hooks/useCancellableInvoke";
 import s from "../styles";
 import { getGitStatusColor, getGitStatusLabel } from "../utils";
 import { useI18n } from "../i18n";
+import { useToast } from "./Toast";
 
 interface GitFileChange {
   path: string;
@@ -43,13 +44,13 @@ export function GitChanges({
   width = 280,
 }: Props) {
   const { t } = useI18n();
+  const { showToast } = useToast();
   const [changes, setChanges] = useState<GitFileChange[]>([]);
   const [loading, setLoading] = useState(false);
   const [tab, setTab] = useState<"task" | "all">("all");
   const [commitMsg, setCommitMsg] = useState("");
   const [committing, setCommitting] = useState(false);
   const [generatingMsg, setGeneratingMsg] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [commitMsgError, setCommitMsgError] = useState(false);
   const [textareaFocused, setTextareaFocused] = useState(false);
   const [trackedCollapsed, setTrackedCollapsed] = useState(false);
@@ -57,19 +58,18 @@ export function GitChanges({
 
   const { safeInvoke, isCancelled } = useCancellableInvoke();
 
-  const refresh = useCallback(async (options?: { clearError?: boolean }) => {
+  const refresh = useCallback(async () => {
     setLoading(true);
-    if (options?.clearError !== false) setError(null);
     try {
       const result = await safeInvoke<GitFileChange[]>("git_status", { projectPath });
       if (result === null) return; // Component unmounted
       setChanges(result);
     } catch (e) {
-      if (!isCancelled()) setError(String(e));
+      if (!isCancelled()) showToast(String(e), "error");
     } finally {
       if (!isCancelled()) setLoading(false);
     }
-  }, [projectPath, safeInvoke, isCancelled]);
+  }, [projectPath, safeInvoke, isCancelled, showToast]);
 
   useEffect(() => {
     refresh();
@@ -97,27 +97,25 @@ export function GitChanges({
       }
       refresh();
     } catch (err) {
-      setError(String(err));
+      showToast(String(err), "error");
     }
   };
 
   const handleStageAll = async () => {
     try {
-      setError(null);
       await invoke("git_stage_all", { projectPath });
       refresh();
     } catch (err) {
-      setError(String(err));
+      showToast(String(err), "error");
     }
   };
 
   const handleUnstageAll = async () => {
     try {
-      setError(null);
       await invoke("git_unstage_all", { projectPath });
       refresh();
     } catch (err) {
-      setError(String(err));
+      showToast(String(err), "error");
     }
   };
 
@@ -135,16 +133,15 @@ export function GitChanges({
     );
     if (!ok) return;
     try {
-      setError(null);
       await invoke("git_discard_file", {
         projectPath,
         filePath: c.path,
         untracked,
       });
     } catch (err) {
-      setError(t("git.discardFailed", { error: String(err) }));
+      showToast(t("git.discardFailed", { error: String(err) }), "error");
     } finally {
-      await refresh({ clearError: false });
+      await refresh();
     }
   };
 
@@ -156,25 +153,23 @@ export function GitChanges({
     });
     if (!ok) return;
     try {
-      setError(null);
       await invoke("git_discard_all", { projectPath });
     } catch (err) {
-      setError(t("git.discardFailed", { error: String(err) }));
+      showToast(t("git.discardFailed", { error: String(err) }), "error");
     } finally {
-      await refresh({ clearError: false });
+      await refresh();
     }
   };
 
   const handleGenerateMsg = async () => {
     setGeneratingMsg(true);
-    setError(null);
     try {
       const msg = await safeInvoke<string>("generate_commit_message", { projectPath });
       if (msg === null) return; // Component unmounted
       setCommitMsg(msg);
       if (commitMsgError) setCommitMsgError(false);
     } catch (err) {
-      if (!isCancelled()) setError(String(err));
+      if (!isCancelled()) showToast(String(err), "error");
     } finally {
       if (!isCancelled()) setGeneratingMsg(false);
     }
@@ -187,13 +182,12 @@ export function GitChanges({
     }
     setCommitMsgError(false);
     setCommitting(true);
-    setError(null);
     try {
       await invoke("git_commit", { projectPath, message: commitMsg.trim() });
       setCommitMsg("");
       refresh();
     } catch (err) {
-      setError(String(err));
+      showToast(String(err), "error");
     } finally {
       setCommitting(false);
     }
@@ -315,23 +309,6 @@ export function GitChanges({
           {t("git.all")} {allCount}
         </button>
       </div>
-
-      {/* Error */}
-      {error && (
-        <div
-          style={{
-            margin: "0 12px 4px",
-            padding: "6px 10px",
-            background: "var(--danger-surface)",
-            border: "1px solid var(--danger-border)",
-            borderRadius: 6,
-            fontSize: 11.5,
-            color: "var(--danger-fg)",
-          }}
-        >
-          {error}
-        </div>
-      )}
 
       {/* File list */}
       <div style={{ flex: 1, overflowY: "auto" }}>

--- a/src/components/GitHistory.tsx
+++ b/src/components/GitHistory.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { getGitStatusColor } from "../utils";
 import { useI18n } from "../i18n";
+import { useToast } from "./Toast";
 
 interface GitCommit {
   hash: string;
@@ -70,6 +71,7 @@ function fileDir(path: string): string {
 
 export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 280 }: Props) {
   const { t } = useI18n();
+  const { showToast } = useToast();
   const [commits, setCommits] = useState<GitCommit[]>([]);
   const [remoteCounts, setRemoteCounts] = useState<GitRemoteCounts>({
     ahead: 0,
@@ -201,12 +203,16 @@ export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 2
 
   const handlePull = async () => {
     setPulling(true);
-    setError(null);
     try {
-      await safeInvoke("git_pull", { projectPath });
-      if (!isCancelled()) refresh();
+      const branch = await safeInvoke<string>("git_pull", { projectPath });
+      if (!isCancelled()) {
+        showToast(t("toast.pullSuccess", { branch: branch || remoteCounts.branch }), "success");
+        refresh();
+      }
     } catch (e) {
-      if (!isCancelled()) setError(String(e));
+      if (!isCancelled()) {
+        showToast(t("toast.pullFailed", { error: String(e) }), "error");
+      }
     } finally {
       if (!isCancelled()) setPulling(false);
     }
@@ -214,15 +220,20 @@ export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 2
 
   const handlePush = async () => {
     setPushing(true);
-    setError(null);
     try {
-      await safeInvoke("git_push", { projectPath, branch: selectedBranch || null });
+      const branch = await safeInvoke<string>("git_push", {
+        projectPath,
+        branch: selectedBranch || null,
+      });
       if (!isCancelled()) {
+        showToast(t("toast.pushSuccess", { branch: branch || selectedBranch }), "success");
         refresh();
         await loadBranches();
       }
     } catch (e) {
-      if (!isCancelled()) setError(String(e));
+      if (!isCancelled()) {
+        showToast(t("toast.pushFailed", { error: String(e) }), "error");
+      }
     } finally {
       if (!isCancelled()) setPushing(false);
     }
@@ -271,16 +282,23 @@ export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 2
               alignItems: "center",
               gap: 3,
               padding: "3px 7px",
-              background: "none",
-              border: "1px solid var(--border-dim)",
+              background: pulling ? "var(--primary-action-bg)" : "none",
+              border: `1px solid ${pulling ? "var(--primary-action-bg)" : "var(--border-dim)"}`,
               borderRadius: 5,
               fontSize: 11.5,
-              color: "var(--text-muted)",
+              color: pulling ? "var(--primary-action-fg)" : "var(--text-muted)",
               cursor: pulling ? "not-allowed" : "pointer",
-              opacity: pulling ? 0.6 : 1,
+              transition: "all 0.15s",
             }}
           >
-            {t("git.pull")} ↓{remoteCounts.behind}
+            {pulling ? (
+              <>
+                <Loader2 size={11} style={{ animation: "spin 1s linear infinite" }} />
+                {t("git.pulling")}
+              </>
+            ) : (
+              <>{t("git.pull")} ↓{remoteCounts.behind}</>
+            )}
           </button>
           <button
             onClick={handlePush}

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -371,6 +371,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "git.committing": "Committing…",
     "git.history": "History",
     "git.pull": "Pull",
+    "git.pulling": "Pulling…",
     "git.push": "Push",
     "git.pushing": "Pushing…",
     "git.searchCommits": "Search commits",
@@ -491,6 +492,10 @@ const translations: Record<AppLanguage, Record<string, string>> = {
       "Failed to load project file list, @ references unavailable: {error}",
     "toast.saveProjectsFailed": "Failed to save project list: {error}",
     "toast.saveTasksFailed": "Failed to save tasks for project {projectId}: {error}",
+    "toast.pushSuccess": "Pushed to {branch}",
+    "toast.pushFailed": "Push failed: {error}",
+    "toast.pullSuccess": "Pulled from {branch}",
+    "toast.pullFailed": "Pull failed: {error}",
   },
   zh: {
     "appSettings.title": "应用设置",
@@ -834,6 +839,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "git.committing": "提交中…",
     "git.history": "历史",
     "git.pull": "拉取",
+    "git.pulling": "拉取中…",
     "git.push": "推送",
     "git.pushing": "推送中…",
     "git.searchCommits": "搜索提交",
@@ -953,6 +959,10 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "toast.loadProjectFilesFailed": "加载项目文件列表失败，@ 引用不可用：{error}",
     "toast.saveProjectsFailed": "保存项目列表失败：{error}",
     "toast.saveTasksFailed": "保存任务失败（项目 {projectId}）：{error}",
+    "toast.pushSuccess": "已推送到 {branch}",
+    "toast.pushFailed": "推送失败：{error}",
+    "toast.pullSuccess": "已从 {branch} 拉取",
+    "toast.pullFailed": "拉取失败：{error}",
   },
 };
 


### PR DESCRIPTION
## Summary
- replace inline Git action errors in Git panels with toast notifications
- add loading and success feedback for push/pull operations
- return the active branch from push/pull commands so success messages stay accurate

## Verification
- pnpm build
- cargo check --manifest-path src-tauri/Cargo.toml --quiet