### PR TITLE
feat(notification): poll for new notifications every 6h

### DIFF
--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -42,6 +42,12 @@ export function NotificationsProvider({ children }: { children: React.ReactNode 
 
   useEffect(() => {
     fetchNotifications();
+    // Long-running desktop app: poll periodically so users who never restart
+    // still receive new notifications. The backend throttles actual remote
+    // fetches to once per hour, so this only triggers a network hit every 6h.
+    const POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
+    const interval = setInterval(fetchNotifications, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
   }, [fetchNotifications]);
 
   const markRead = useCallback(async (id: string) => {


### PR DESCRIPTION
The notification list was only fetched once on provider mount, so users who keep the app running (the common case for a long-lived desktop app) never saw new notifications until a restart. Add a 6h setInterval that re-fetches; the backend's 1h throttle still caps real remote requests.