### PR TITLE
macOS去除标题栏

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "core:window:allow-set-theme",
     "core:window:allow-hide",
+    "core:window:allow-start-dragging",
+    "core:window:allow-internal-toggle-maximize",
     "opener:default",
     "dialog:default"
   ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,12 @@
         "height": 720,
         "minWidth": 900,
         "minHeight": 580,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 6,
+          "y": 10
+        },
         "acceptFirstMouse": true
       }
     ],

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -10,6 +10,7 @@ import { writeClipboardText } from "./file-explorer/clipboard";
 import { FileExplorerContextMenu } from "./file-explorer/ContextMenu";
 import { CreateInputRow } from "./file-explorer/CreateInputRow";
 import { TreeItem } from "./file-explorer/TreeItem";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import {
   AUTO_REFRESH_MS,
   ROW_HEIGHT,
@@ -422,8 +423,10 @@ export function FileExplorer({
         />
       )}
       {/* Header */}
-      <div style={s.fileExplorerHeader}>
-        <span style={s.fileExplorerHeaderTitle}>{t("file.files")}</span>
+      <div {...windowDragRegion} style={s.fileExplorerHeader}>
+        <span style={{ ...s.fileExplorerHeaderTitle, ...windowDragPassthrough }}>
+          {t("file.files")}
+        </span>
         <button
           onClick={() => void refresh()}
           title={t("common.refresh")}

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -35,6 +35,7 @@ import { ImagePreviewPane } from "./file-viewer/ImagePreviewPane";
 import type { OpenFileTab } from "../hooks/useProjectPanels";
 import type { ThemeVariant } from "../types";
 import { useI18n } from "../i18n";
+import { windowDragRegion } from "../windowDrag";
 
 function isMarkdownFile(fileName: string): boolean {
   const ext = fileName.split(".").pop()?.toLowerCase();
@@ -611,6 +612,7 @@ export function FileViewer({
         }}
       >
         <div
+          {...windowDragRegion}
           className="file-viewer-tab-strip"
           style={{
             flex: 1,

--- a/src/components/GitChanges.tsx
+++ b/src/components/GitChanges.tsx
@@ -20,6 +20,7 @@ import {
   type GitDirectoryActionTarget,
   useGitFileViewMode,
 } from "./git-view/GitFileBrowser";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 
 interface GitFileChange {
   path: string;
@@ -328,6 +329,7 @@ export function GitChanges({
     >
       {/* Header */}
       <div
+        {...windowDragRegion}
         style={{
           height: 48,
           display: "flex",
@@ -338,7 +340,15 @@ export function GitChanges({
           gap: 6,
         }}
       >
-        <span style={{ flex: 1, fontSize: 13, fontWeight: 650, color: "var(--text-primary)" }}>
+        <span
+          style={{
+            flex: 1,
+            fontSize: 13,
+            fontWeight: 650,
+            color: "var(--text-primary)",
+            ...windowDragPassthrough,
+          }}
+        >
           {t("git.changes")}
         </span>
         <button

--- a/src/components/GitDiffViewer.tsx
+++ b/src/components/GitDiffViewer.tsx
@@ -7,6 +7,7 @@ import { parseDiff } from "./git-diff/parse";
 import type { DiffViewMode } from "./git-diff/types";
 import { load, save } from "../utils";
 import { useI18n } from "../i18n";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import s from "../styles";
 
 const VIEW_MODE_KEY = "nezha.diffViewMode";
@@ -120,9 +121,11 @@ export function GitDiffViewer({
 
   return (
     <div style={s.diffViewer}>
-      <div style={s.diffHeader}>
-        <FileCode size={15} color="var(--text-muted)" />
-        <div style={s.diffHeaderTitleWrap}>
+      <div {...windowDragRegion} style={s.diffHeader}>
+        <span style={{ display: "inline-flex", ...windowDragPassthrough }}>
+          <FileCode size={15} color="var(--text-muted)" />
+        </span>
+        <div style={{ ...s.diffHeaderTitleWrap, ...windowDragPassthrough }}>
           <div style={s.diffHeaderTitle}>{title}</div>
           <div style={s.diffHeaderMeta}>
             <span>

--- a/src/components/GitHistory.tsx
+++ b/src/components/GitHistory.tsx
@@ -17,6 +17,7 @@ import {
   GitFileViewToggle,
   useGitFileViewMode,
 } from "./git-view/GitFileBrowser";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 
 interface GitCommit {
   hash: string;
@@ -245,6 +246,7 @@ export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 2
         }}
       >
         <div
+          {...windowDragRegion}
           style={{
             height: 48,
             display: "flex",
@@ -253,7 +255,15 @@ export function GitHistory({ projectPath, onCommitSelect, onFileClick, width = 2
             gap: 4,
           }}
         >
-          <span style={{ fontSize: 13, fontWeight: 650, color: "var(--text-primary)", flex: 1 }}>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 650,
+              color: "var(--text-primary)",
+              flex: 1,
+              ...windowDragPassthrough,
+            }}
+          >
             {t("git.history")}
           </span>
 

--- a/src/components/NewTaskView.tsx
+++ b/src/components/NewTaskView.tsx
@@ -27,6 +27,7 @@ import {
   normalizeSendShortcut,
   type SendShortcut,
 } from "../shortcuts";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import claudeGif from "../assets/gif/claude.gif";
 import codexGif from "../assets/gif/codex.gif";
 import s from "../styles";
@@ -423,13 +424,13 @@ export function NewTaskView({
   return (
     <div style={s.newTaskOuter}>
       {/* Header */}
-      <div style={s.newTaskHeader}>
+      <div {...windowDragRegion} style={s.newTaskHeader}>
         <img
           src={agent === "claude" ? claudeGif : codexGif}
           alt=""
-          style={s.newTaskClaudeGif}
+          style={{ ...s.newTaskClaudeGif, ...windowDragPassthrough }}
         />
-        <span style={s.newTaskTitle}>{t("newTask.title")}</span>
+        <span style={{ ...s.newTaskTitle, ...windowDragPassthrough }}>{t("newTask.title")}</span>
       </div>
 
       {/* Missing context file warning */}

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -4,6 +4,7 @@ import type { Project, Task } from "../types";
 import { ProjectAvatar } from "./ProjectAvatar";
 import { useI18n } from "../i18n";
 import { APP_PLATFORM } from "../platform";
+import { windowDragRegion } from "../windowDrag";
 import s from "../styles";
 import claudeWaveGif from "../assets/gif/claude-wave.gif";
 
@@ -377,6 +378,7 @@ export function ProjectRail({
 
   return (
     <div
+      {...windowDragRegion}
       style={{
         position: "relative",
         width: 52,

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -3,8 +3,11 @@ import { Plus, ChevronsRight, Search, PinOff } from "lucide-react";
 import type { Project, Task } from "../types";
 import { ProjectAvatar } from "./ProjectAvatar";
 import { useI18n } from "../i18n";
+import { APP_PLATFORM } from "../platform";
 import s from "../styles";
 import claudeWaveGif from "../assets/gif/claude-wave.gif";
+
+const MAC_TRAFFIC_LIGHT_SAFE_TOP = 26;
 
 type ProjectStatus = "attention" | "running" | null;
 
@@ -383,7 +386,7 @@ export function ProjectRail({
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        paddingTop: 10,
+        paddingTop: APP_PLATFORM === "macos" ? MAC_TRAFFIC_LIGHT_SAFE_TOP : 10,
         paddingBottom: 10,
         gap: 5,
         overflow: "visible",

--- a/src/components/RunningView.tsx
+++ b/src/components/RunningView.tsx
@@ -11,6 +11,7 @@ import { shortenPath, getUsageColor } from "../utils";
 import { useUsageSnapshot } from "../hooks/useUsageSnapshot";
 import { ENABLE_USAGE_INSIGHTS } from "../platform";
 import { useI18n } from "../i18n";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import s from "../styles";
 import {
   X,
@@ -255,12 +256,18 @@ export function RunningView({
     >
       {/* Header */}
       <div
+        {...windowDragRegion}
         style={s.runHeader}
         onMouseEnter={() => setHoverHeader(true)}
         onMouseLeave={() => setHoverHeader(false)}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 10, flex: 1, minWidth: 0 }}>
-          <StatusIcon status={task.status} />
+        <div
+          {...windowDragRegion}
+          style={{ display: "flex", alignItems: "center", gap: 10, flex: 1, minWidth: 0 }}
+        >
+          <span style={{ display: "inline-flex", ...windowDragPassthrough }}>
+            <StatusIcon status={task.status} />
+          </span>
           {editingTitle ? (
             <input
               ref={titleInputRef}
@@ -304,6 +311,7 @@ export function RunningView({
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 whiteSpace: "nowrap",
+                ...windowDragPassthrough,
               }}
             >
               {(() => {

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -19,6 +19,7 @@ import {
 import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import { Plus, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { useI18n } from "../i18n";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import "@xterm/xterm/css/xterm.css";
 
 interface ShellOutputEvent {
@@ -376,6 +377,7 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
           />
         )}
         <div
+          {...windowDragRegion}
           style={{
             height: 32,
             flexShrink: 0,
@@ -387,10 +389,18 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
             gap: 8,
           }}
         >
-          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-primary)", flex: 1 }}>
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--text-primary)",
+              flex: 1,
+              ...windowDragPassthrough,
+            }}
+          >
             {t("terminal.title")}
           </span>
-          <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+          <span style={{ fontSize: 11, color: "var(--text-muted)", ...windowDragPassthrough }}>
             {shells.length}/{MAX_SHELLS}
           </span>
           <button

--- a/src/components/TaskPanel.tsx
+++ b/src/components/TaskPanel.tsx
@@ -15,6 +15,7 @@ import { SidebarFooterActions } from "./SidebarFooterActions";
 import { BranchBar } from "./task-panel/BranchBar";
 import { TaskList } from "./task-panel/TaskList";
 import { useI18n } from "../i18n";
+import { windowDragPassthrough, windowDragRegion } from "../windowDrag";
 import s from "../styles";
 
 export function TaskPanel({
@@ -133,12 +134,12 @@ export function TaskPanel({
   return (
     <div style={s.taskPanel}>
       {/* Project header */}
-      <div style={s.panelHeader}>
+      <div {...windowDragRegion} style={s.panelHeader}>
         <button style={s.backBtn} onClick={onBack} title={backTitle ?? t("task.switchProject")}>
           <ChevronLeft size={15} strokeWidth={2} />
         </button>
-        <ProjectAvatar name={project.name} size={22} />
-        <span style={s.panelProjectName}>{project.name}</span>
+        <ProjectAvatar name={project.name} size={22} style={windowDragPassthrough} />
+        <span style={{ ...s.panelProjectName, ...windowDragPassthrough }}>{project.name}</span>
         <button
           type="button"
           style={s.panelCollapseBtn}

--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -29,6 +29,7 @@ import { TimelineView } from "./TimelineView";
 import { SkillHubView } from "./skill-hub/SkillHubView";
 import { useI18n, pluralKey } from "../i18n";
 import { APP_PLATFORM } from "../platform";
+import { windowDragRegion } from "../windowDrag";
 import s from "../styles";
 
 const MAC_TRAFFIC_LIGHT_SAFE_TOP = 34;
@@ -240,7 +241,7 @@ export function WelcomePage({
           />
         ) : (
           <div style={s.welcomePane}>
-            <div style={s.searchRow}>
+            <div {...windowDragRegion} style={s.searchRow}>
               <div
                 style={{
                   ...s.searchBox,

--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -28,7 +28,10 @@ import { OPEN_APP_SETTINGS_EVENT } from "./app-settings/types";
 import { TimelineView } from "./TimelineView";
 import { SkillHubView } from "./skill-hub/SkillHubView";
 import { useI18n, pluralKey } from "../i18n";
+import { APP_PLATFORM } from "../platform";
 import s from "../styles";
+
+const MAC_TRAFFIC_LIGHT_SAFE_TOP = 34;
 
 function SidebarItem({
   icon,
@@ -154,7 +157,12 @@ export function WelcomePage({
   return (
     <div style={s.welcomeBody}>
       <div style={s.welcomeMain}>
-        <div style={s.sidebar}>
+        <div
+          style={{
+            ...s.sidebar,
+            paddingTop: APP_PLATFORM === "macos" ? MAC_TRAFFIC_LIGHT_SAFE_TOP : 18,
+          }}
+        >
           <div style={s.sidebarBrand}>
             <div style={s.sidebarBrandIcon}>
               <span style={s.sidebarBrandBadge}>NZ</span>

--- a/src/components/skill-hub/SkillHubView.tsx
+++ b/src/components/skill-hub/SkillHubView.tsx
@@ -7,6 +7,7 @@ import { useI18n } from "../../i18n";
 import { SKILL_HUB_CHANGED_EVENT } from "../app-settings/types";
 import { shortenPath } from "../../utils";
 import { SkillManageDialog } from "./SkillManageDialog";
+import { windowDragRegion } from "../../windowDrag";
 import s from "../../styles";
 
 interface Props {
@@ -109,10 +110,10 @@ export function SkillHubView({ config, allProjects, onEnterSkillHub, onOpenAppSe
 
   return (
     <div style={s.skillHubBody}>
-      <div style={s.skillHubHeader}>
-        <div style={s.skillHubHeaderMain}>
-          <div style={s.skillHubHeaderTitle}>{t("skill.header.title")}</div>
-          <div style={s.skillHubHeaderPath} title={config.hubPath}>
+      <div {...windowDragRegion} style={s.skillHubHeader}>
+        <div {...windowDragRegion} style={s.skillHubHeaderMain}>
+          <div {...windowDragRegion} style={s.skillHubHeaderTitle}>{t("skill.header.title")}</div>
+          <div {...windowDragRegion} style={s.skillHubHeaderPath} title={config.hubPath}>
             {shortenPath(config.hubPath)}
           </div>
         </div>

--- a/src/windowDrag.ts
+++ b/src/windowDrag.ts
@@ -1,0 +1,9 @@
+import type React from "react";
+
+export const windowDragRegion = {
+  "data-tauri-drag-region": "",
+} satisfies { "data-tauri-drag-region": string };
+
+export const windowDragPassthrough = {
+  pointerEvents: "none",
+} satisfies React.CSSProperties;


### PR DESCRIPTION
mac系统去除标题栏，交通灯保留左上角，调整相关组件位置
<img width="2200" height="1440" alt="image" src="https://github.com/user-attachments/assets/4905c825-a99d-48f4-a691-035965550b7f" />
<img width="2200" height="1440" alt="image" src="https://github.com/user-attachments/assets/2e89d6fc-8d65-41fe-abec-bd475df57e46" />
