### PR TITLE
[codex] Align terminal spacing and chat background

### DIFF
--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -24,6 +24,12 @@ import {
 import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import "@xterm/xterm/css/xterm.css";
 
+function chatTerminalThemeFor(themeVariant: ThemeVariant) {
+  const theme = themeFor(themeVariant);
+  if (themeVariant !== "dark") return theme;
+  return { ...theme, background: "#2b313d" };
+}
+
 interface TerminalViewProps {
   onInput: (data: string) => void;
   onResize: (cols: number, rows: number) => void;
@@ -85,6 +91,7 @@ export function TerminalView({
     const container = containerRef.current;
 
     const { term, fitAddon } = initTerminal(themeVariant, 1000, terminalFontSize, monoFontFamily);
+    term.options.theme = chatTerminalThemeFor(themeVariant);
     terminalRef.current = term;
     fitAddonRef.current = fitAddon;
 
@@ -226,7 +233,7 @@ export function TerminalView({
 
   useEffect(() => {
     if (terminalRef.current) {
-      terminalRef.current.options.theme = themeFor(themeVariant);
+      terminalRef.current.options.theme = chatTerminalThemeFor(themeVariant);
     }
   }, [themeVariant]);
 

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -304,6 +304,67 @@ export interface InitTerminalResult {
   fitAddon: FitAddon;
 }
 
+interface TerminalMetricsCore {
+  _charSizeService?: {
+    width: number;
+    height: number;
+  };
+  _renderService?: {
+    handleCharSizeChanged: () => void;
+  };
+}
+
+const DOM_MEASURE_REPEAT = 32;
+
+function measureTerminalFontWithDom(
+  term: Terminal,
+  container: HTMLElement,
+): { width: number; height: number } | null {
+  // xterm 在支持 OffscreenCanvas 时会用 canvas measureText 测量字符宽度；
+  // WKWebView + Nerd Font 下这个结果可能和真实 DOM 排版不一致，导致 WebGL cell 宽度偏移。
+  const measure = container.ownerDocument.createElement("span");
+  measure.classList.add("xterm-char-measure-element");
+  measure.textContent = "W".repeat(DOM_MEASURE_REPEAT);
+  measure.setAttribute("aria-hidden", "true");
+  measure.style.whiteSpace = "pre";
+  measure.style.fontKerning = "none";
+  measure.style.fontFamily = term.options.fontFamily ?? "monospace";
+  measure.style.fontSize = `${term.options.fontSize ?? 12}px`;
+  measure.style.fontWeight = String(term.options.fontWeight ?? "normal");
+  container.appendChild(measure);
+
+  const width = measure.offsetWidth / DOM_MEASURE_REPEAT;
+  const height = measure.offsetHeight;
+  measure.remove();
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+function syncTerminalFontMetrics(term: Terminal, container: HTMLElement): void {
+  // WebGL renderer 的 cell dimensions 来自 _charSizeService；这里用 DOM 实测值校正它，
+  // 让 FitAddon 和 WebGL glyph atlas 使用同一套字符宽度。
+  const core = (term as unknown as { _core?: TerminalMetricsCore })._core;
+  const charSizeService = core?._charSizeService;
+  const renderService = core?._renderService;
+  if (!charSizeService || !renderService) return;
+
+  const measured = measureTerminalFontWithDom(term, container);
+  if (!measured) return;
+
+  const changed =
+    Math.abs(charSizeService.width - measured.width) > 0.01 ||
+    Math.abs(charSizeService.height - measured.height) > 0.01;
+  if (!changed) return;
+
+  charSizeService.width = measured.width;
+  charSizeService.height = measured.height;
+  renderService.handleCharSizeChanged();
+  term.refresh(0, term.rows - 1);
+}
+
 /**
  * 创建 xterm Terminal 实例并加载通用 addon（FitAddon, Unicode11, WebGL）。
  * 调用方负责 term.open(container)。
@@ -388,12 +449,16 @@ export function safeFit(
   if (container) {
     const rect = container.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return null;
+    // proposeDimensions 依赖 renderer dimensions，先同步一次才能用正确 cell 宽度计算列数。
+    syncTerminalFontMetrics(term, container);
   }
   try {
     const dims = fitAddon.proposeDimensions();
     if (!dims || !Number.isFinite(dims.cols) || !Number.isFinite(dims.rows)) return null;
     if (dims.cols < 2 || dims.rows < 2) return null;
     fitAddon.fit();
+    // fit/resize 后 WebGL renderer 可能重算 dimensions，再补一次避免窗口缩放后宽度回退。
+    if (container) syncTerminalFontMetrics(term, container);
     return { cols: term.cols, rows: term.rows };
   } catch {
     return null;

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -398,6 +398,41 @@ export function initTerminal(
   return { term, fitAddon };
 }
 
+function refreshWebglAtlasAfterFontReady(term: Terminal, webglAddon: WebglAddon): void {
+  const ownerDocument = term.element?.ownerDocument ?? document;
+  const ownerWindow = ownerDocument.defaultView ?? window;
+  const fontSize = term.options.fontSize ?? 12;
+  const fontFamily = term.options.fontFamily ?? "monospace";
+  const fontWeight = term.options.fontWeight ?? "normal";
+  const fontSpec = `${fontWeight} ${fontSize}px ${fontFamily}`;
+
+  const refreshAtlas = () => {
+    if (!term.element) return;
+    try {
+      webglAddon.clearTextureAtlas();
+      term.refresh(0, term.rows - 1);
+    } catch {
+      /* 终端已卸载或 WebGL context 已丢失时忽略。 */
+    }
+  };
+
+  // 首次 WebGL atlas warmup 可能早于 WKWebView 完成 Nerd Font 的 canvas font 匹配，
+  // 于是默认色 ASCII 被缓存成 fallback 字形。字体 ready 后清一次 atlas，等价于用户手动
+  // 改字体大小触发的重新栅格化。
+  const fontsReady = ownerDocument.fonts
+    ? Promise.allSettled([
+        ownerDocument.fonts.ready,
+        ownerDocument.fonts.load(fontSpec, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
+      ]).then(() => undefined)
+    : Promise.resolve();
+
+  fontsReady.finally(() => {
+    ownerWindow.requestAnimationFrame(() => {
+      ownerWindow.requestAnimationFrame(refreshAtlas);
+    });
+  });
+}
+
 /**
  * 尝试加载 WebGL addon，失败时静默降级。
  * 必须在 term.open() 之后调用。
@@ -420,6 +455,7 @@ export function loadWebglAddon(term: Terminal): void {
       webglAddon.dispose();
     });
     term.loadAddon(webglAddon);
+    refreshWebglAtlasAfterFontReady(term, webglAddon);
   } catch (err) {
     console.warn("[terminal] WebGL addon unavailable; using xterm DOM renderer", err);
     /* 不支持 WebGL 时降级，不影响功能 */

--- a/src/styles/terminal.ts
+++ b/src/styles/terminal.ts
@@ -74,7 +74,7 @@ export const terminal = {
     cursor: "pointer",
     flexShrink: 0,
   },
-  terminalContainer: { flex: 1, overflow: "hidden" as const, padding: "14px 16px 16px" },
+  terminalContainer: { flex: 1, overflow: "hidden" as const, padding: 10 },
   interruptedSessionWrap: {
     flex: 1,
     minHeight: 0,


### PR DESCRIPTION
修改agent对话xterm容器的填充为10px

将中间agent对话的xterm背景与周围主面板在暗色主题中对齐

保持下方shell终端保留其原始背景
