### PR TITLE
[codex] Fix terminal contrast in light themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ bump-version.sh
 vite.config.js
 vite.config.d.ts
 .codex
+.codegraph/
+.planning/
+pnpm-workspace.yaml

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -7,11 +7,12 @@ import { FitAddon } from "@xterm/addon-fit";
 import { attachSmartCopy } from "./terminalCopyHelper";
 import type { TerminalFontSize, FontFamily, ThemeVariant } from "../types";
 import {
-  themeFor,
+  applyTerminalTheme,
   initTerminal,
   loadWebglAddon,
   safeFit,
   createSmartWriter,
+  themeFor,
   attachMacWebKitTerminalGuard,
   applyTerminalFontSize,
   applyTerminalFontFamily,
@@ -228,7 +229,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
 
     useEffect(() => {
       if (terminalRef.current) {
-        terminalRef.current.options.theme = themeFor(themeVariant);
+        applyTerminalTheme(terminalRef.current, themeVariant);
       }
     }, [themeVariant]);
 

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -12,7 +12,7 @@ import {
 } from "../shortcuts";
 import type { TerminalFontSize, FontFamily, ThemeVariant } from "../types";
 import {
-  themeFor,
+  applyTerminalTheme,
   initTerminal,
   loadWebglAddon,
   safeFit,
@@ -226,7 +226,7 @@ export function TerminalView({
 
   useEffect(() => {
     if (terminalRef.current) {
-      terminalRef.current.options.theme = themeFor(themeVariant);
+      applyTerminalTheme(terminalRef.current, themeVariant);
     }
   }, [themeVariant]);
 

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -87,6 +87,15 @@ export function themeFor(variant: ThemeVariant) {
   return LIGHT_THEME;
 }
 
+export function minimumContrastRatioFor(variant: ThemeVariant): number {
+  return variant === "dark" ? 1 : 4.5;
+}
+
+export function applyTerminalTheme(term: Terminal, variant: ThemeVariant): void {
+  term.options.theme = themeFor(variant);
+  term.options.minimumContrastRatio = minimumContrastRatioFor(variant);
+}
+
 // ── Watermark flow control ───────────────────────────────────────────────────
 
 const HIGH_WATER = 128 * 1024; // 128 KB：超过时停止写入
@@ -325,6 +334,7 @@ export function initTerminal(
     fontFamily,
     fontSize,
     theme: themeFor(variant),
+    minimumContrastRatio: minimumContrastRatioFor(variant),
     allowProposedApi: true,
     overviewRuler: { width: XTERM_OVERLAY_SCROLLBAR_WIDTH },
     // 当运行中的 TUI（Claude Code / Codex）开启鼠标上报时，xterm 默认把拖动当作

--- a/src/test/terminal-theme.test.ts
+++ b/src/test/terminal-theme.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import {
+  DARK_THEME,
+  EYECARE_THEME,
+  LIGHT_THEME,
+  minimumContrastRatioFor,
+  themeFor,
+} from "../components/terminalShared";
+
+describe("terminal theme helpers", () => {
+  test("returns the configured xterm palette for each app theme", () => {
+    expect(themeFor("dark")).toBe(DARK_THEME);
+    expect(themeFor("light")).toBe(LIGHT_THEME);
+    expect(themeFor("eyecare")).toBe(EYECARE_THEME);
+  });
+
+  test("enforces readable terminal colors on light backgrounds", () => {
+    expect(minimumContrastRatioFor("light")).toBe(4.5);
+    expect(minimumContrastRatioFor("eyecare")).toBe(4.5);
+    expect(minimumContrastRatioFor("dark")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- enable xterm minimum contrast protection for light and eyecare themes
- apply the shared terminal theme helper to both task terminals and embedded shell terminals
- add regression coverage for terminal theme contrast helpers
- ignore local CodeGraph data directories

## Root cause
Claude Code can emit ANSI or truecolor foreground colors that are readable on dark terminals but nearly invisible on Nezha's light backgrounds. xterm defaults `minimumContrastRatio` to 1, so those low-contrast colors were rendered unchanged.

## Upstream PR requirements checked
- No `CONTRIBUTING.md` found in `hanshuaikang/nezha`.
- No `.github/PULL_REQUEST_TEMPLATE.md` found.
- Source CI `.github/workflows/checks.yml` runs cargo audit, lint, tests, and web build.

## Validation
- `cargo audit` completed with exit code 0; it reported existing allowed warnings from current dependencies.
- `./node_modules/.bin/eslint src --max-warnings 0`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc && ./node_modules/.bin/vite build`

Note: `pnpm lint/test` on this machine is blocked by pnpm 11 build-approval state for esbuild, while upstream CI uses pnpm 9 with `--ignore-scripts`. The underlying lint/test/build commands above pass.