### PR TITLE
fix(theme) eyecare theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,20 @@ import { APP_PLATFORM } from "./platform";
 import { useTerminalManager } from "./hooks/useTerminalManager";
 import { useWorktreeDiffStats } from "./hooks/useWorktreeDiffStats";
 import { useI18n } from "./i18n";
+import {
+  DARK_THEME_STORAGE_KEY,
+  getNextThemeMode,
+  getPreferredDarkTheme,
+  getPreferredLightTheme,
+  isDarkThemeMode,
+  isLightThemeMode,
+  isThemeMode,
+  LIGHT_THEME_STORAGE_KEY,
+  resolveThemeVariant,
+  THEME_STORAGE_KEY,
+  type DarkThemeMode,
+  type LightThemeMode,
+} from "./theme";
 import s from "./styles";
 import "./App.css";
 
@@ -141,19 +155,19 @@ function getSystemPrefersDark() {
 }
 
 function getInitialThemeMode(): ThemeMode {
-  const stored = localStorage.getItem("nezha:theme");
-  return stored === "dark" ||
-    stored === "light" ||
-    stored === "system" ||
-    stored === "eyecare" ||
-    stored === "midnight"
-    ? stored
-    : "system";
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return isThemeMode(stored) ? stored : "system";
 }
 
-function resolveThemeVariant(mode: ThemeMode, systemPrefersDark: boolean): ThemeVariant {
-  if (mode === "system") return systemPrefersDark ? "midnight" : "light";
-  return mode;
+function getInitialLightThemeMode(): LightThemeMode {
+  return getPreferredLightTheme(
+    getInitialThemeMode(),
+    localStorage.getItem(LIGHT_THEME_STORAGE_KEY),
+  );
+}
+
+function getInitialDarkThemeMode(): DarkThemeMode {
+  return getPreferredDarkTheme(getInitialThemeMode(), localStorage.getItem(DARK_THEME_STORAGE_KEY));
 }
 
 function getInitialTerminalFontSize(): TerminalFontSize {
@@ -192,6 +206,8 @@ function App() {
   const { t } = useI18n();
 
   const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialThemeMode);
+  const [lightThemeMode, setLightThemeMode] = useState<LightThemeMode>(getInitialLightThemeMode);
+  const [darkThemeMode, setDarkThemeMode] = useState<DarkThemeMode>(getInitialDarkThemeMode);
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
   const themeVariant: ThemeVariant = resolveThemeVariant(themeMode, systemPrefersDark);
   const [terminalFontSize, setTerminalFontSize] = useState<TerminalFontSize>(
@@ -288,8 +304,16 @@ function App() {
     root.classList.toggle("dark", themeVariant === "dark" || themeVariant === "midnight");
     root.classList.toggle("midnight", themeVariant === "midnight");
     root.classList.toggle("eyecare", themeVariant === "eyecare");
-    localStorage.setItem("nezha:theme", themeMode);
+    localStorage.setItem(THEME_STORAGE_KEY, themeMode);
   }, [themeVariant, themeMode]);
+
+  useEffect(() => {
+    localStorage.setItem(LIGHT_THEME_STORAGE_KEY, lightThemeMode);
+  }, [lightThemeMode]);
+
+  useEffect(() => {
+    localStorage.setItem(DARK_THEME_STORAGE_KEY, darkThemeMode);
+  }, [darkThemeMode]);
 
   useEffect(() => {
     // Tauri window theme only understands light/dark/null; map eyecare to light
@@ -351,18 +375,17 @@ function App() {
     document.documentElement.style.setProperty("--font-mono", effective);
   }, [monoFontFamily]);
 
+  const handleThemeModeChange = useCallback((mode: ThemeMode) => {
+    if (isLightThemeMode(mode)) setLightThemeMode(mode);
+    if (isDarkThemeMode(mode)) setDarkThemeMode(mode);
+    setThemeMode(mode);
+  }, []);
+
   const handleToggleTheme = useCallback(() => {
     setThemeMode((currentMode) => {
-      // Toggle only cycles between the canonical light/dark pair. The dark side
-      // defaults to midnight (neutral near-black surfaces); eyecare and any
-      // future opt-in variants retreat to "light" so the shortcut remains a
-      // one-tap escape hatch.
-      if (currentMode === "dark" || currentMode === "midnight") return "light";
-      if (currentMode === "light") return "midnight";
-      if (currentMode === "system") return systemPrefersDark ? "light" : "midnight";
-      return "light";
+      return getNextThemeMode(currentMode, systemPrefersDark, lightThemeMode, darkThemeMode);
     });
-  }, [systemPrefersDark]);
+  }, [darkThemeMode, lightThemeMode, systemPrefersDark]);
 
   useEffect(() => {
     async function init() {
@@ -1189,7 +1212,7 @@ function App() {
               themeVariant={themeVariant}
               themeMode={themeMode}
               systemPrefersDark={systemPrefersDark}
-              onThemeModeChange={setThemeMode}
+              onThemeModeChange={handleThemeModeChange}
               onToggleTheme={handleToggleTheme}
               terminalFontSize={terminalFontSize}
               onTerminalFontSizeChange={setTerminalFontSize}
@@ -1226,7 +1249,7 @@ function App() {
             themeVariant={themeVariant}
             themeMode={themeMode}
             systemPrefersDark={systemPrefersDark}
-            onThemeModeChange={setThemeMode}
+            onThemeModeChange={handleThemeModeChange}
             onToggleTheme={handleToggleTheme}
             terminalFontSize={terminalFontSize}
             onTerminalFontSizeChange={setTerminalFontSize}

--- a/src/test/theme.test.ts
+++ b/src/test/theme.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import {
+  getNextThemeMode,
+  getPreferredDarkTheme,
+  getPreferredLightTheme,
+  isThemeMode,
+  resolveThemeVariant,
+} from "../theme";
+
+describe("theme helpers", () => {
+  test("resolves system mode from the OS preference", () => {
+    expect(resolveThemeVariant("system", true)).toBe("midnight");
+    expect(resolveThemeVariant("system", false)).toBe("light");
+    expect(resolveThemeVariant("eyecare", false)).toBe("eyecare");
+    expect(resolveThemeVariant("dark", false)).toBe("dark");
+  });
+
+  test("recognizes persisted theme modes", () => {
+    expect(isThemeMode("dark")).toBe(true);
+    expect(isThemeMode("midnight")).toBe(true);
+    expect(isThemeMode("light")).toBe(true);
+    expect(isThemeMode("system")).toBe(true);
+    expect(isThemeMode("eyecare")).toBe(true);
+    expect(isThemeMode("white")).toBe(false);
+  });
+
+  test("keeps eyecare as the preferred light theme after midnight mode", () => {
+    const preferredLightTheme = getPreferredLightTheme("eyecare", null);
+    const preferredDarkTheme = getPreferredDarkTheme("eyecare", null);
+
+    expect(getNextThemeMode("eyecare", false, preferredLightTheme, preferredDarkTheme)).toBe(
+      "midnight",
+    );
+    expect(getNextThemeMode("midnight", false, preferredLightTheme, preferredDarkTheme)).toBe(
+      "eyecare",
+    );
+  });
+
+  test("restores persisted light and dark preferences", () => {
+    const preferredLightTheme = getPreferredLightTheme("dark", "eyecare");
+    const preferredDarkTheme = getPreferredDarkTheme("light", "dark");
+
+    expect(preferredLightTheme).toBe("eyecare");
+    expect(preferredDarkTheme).toBe("dark");
+    expect(getNextThemeMode("dark", false, preferredLightTheme, preferredDarkTheme)).toBe(
+      "eyecare",
+    );
+    expect(getNextThemeMode("light", false, preferredLightTheme, preferredDarkTheme)).toBe("dark");
+  });
+
+  test("uses current manual theme as the matching preference", () => {
+    expect(getPreferredLightTheme("eyecare", "light")).toBe("eyecare");
+    expect(getPreferredDarkTheme("dark", "midnight")).toBe("dark");
+  });
+
+  test("falls back when no valid preference exists", () => {
+    const preferredLightTheme = getPreferredLightTheme("midnight", "white");
+    const preferredDarkTheme = getPreferredDarkTheme("light", "black");
+
+    expect(preferredLightTheme).toBe("light");
+    expect(preferredDarkTheme).toBe("midnight");
+    expect(getNextThemeMode("midnight", false, preferredLightTheme, preferredDarkTheme)).toBe(
+      "light",
+    );
+    expect(getNextThemeMode("light", false, preferredLightTheme, preferredDarkTheme)).toBe(
+      "midnight",
+    );
+  });
+
+  test("switches from system mode to the opposite preferred theme family", () => {
+    const preferredLightTheme = getPreferredLightTheme("system", "eyecare");
+    const preferredDarkTheme = getPreferredDarkTheme("system", "dark");
+
+    expect(getNextThemeMode("system", true, preferredLightTheme, preferredDarkTheme)).toBe(
+      "eyecare",
+    );
+    expect(getNextThemeMode("system", false, preferredLightTheme, preferredDarkTheme)).toBe("dark");
+  });
+});

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,60 @@
+import type { ThemeMode, ThemeVariant } from "./types";
+
+export type LightThemeMode = Extract<ThemeMode, "light" | "eyecare">;
+export type DarkThemeMode = Extract<ThemeMode, "dark" | "midnight">;
+
+export const THEME_STORAGE_KEY = "nezha:theme";
+export const LIGHT_THEME_STORAGE_KEY = "nezha:lightTheme";
+export const DARK_THEME_STORAGE_KEY = "nezha:darkTheme";
+
+export function isThemeMode(value: string | null): value is ThemeMode {
+  return (
+    value === "dark" ||
+    value === "midnight" ||
+    value === "light" ||
+    value === "system" ||
+    value === "eyecare"
+  );
+}
+
+export function isLightThemeMode(value: string | null): value is LightThemeMode {
+  return value === "light" || value === "eyecare";
+}
+
+export function isDarkThemeMode(value: string | null): value is DarkThemeMode {
+  return value === "dark" || value === "midnight";
+}
+
+export function resolveThemeVariant(
+  mode: ThemeMode,
+  systemPrefersDark: boolean,
+): ThemeVariant {
+  if (mode === "system") return systemPrefersDark ? "midnight" : "light";
+  return mode;
+}
+
+export function getPreferredLightTheme(
+  themeMode: ThemeMode,
+  storedLightTheme: string | null,
+): LightThemeMode {
+  if (isLightThemeMode(themeMode)) return themeMode;
+  return isLightThemeMode(storedLightTheme) ? storedLightTheme : "light";
+}
+
+export function getPreferredDarkTheme(
+  themeMode: ThemeMode,
+  storedDarkTheme: string | null,
+): DarkThemeMode {
+  if (isDarkThemeMode(themeMode)) return themeMode;
+  return isDarkThemeMode(storedDarkTheme) ? storedDarkTheme : "midnight";
+}
+
+export function getNextThemeMode(
+  currentMode: ThemeMode,
+  systemPrefersDark: boolean,
+  preferredLightTheme: LightThemeMode,
+  preferredDarkTheme: DarkThemeMode,
+): ThemeMode {
+  const currentVariant = resolveThemeVariant(currentMode, systemPrefersDark);
+  return isDarkThemeMode(currentVariant) ? preferredLightTheme : preferredDarkTheme;
+}


### PR DESCRIPTION
## Summary

- Preserve the selected light-family theme when using the lower-left light/dark shortcut.
- Add theme transition helpers and regression coverage for eyecare mode.

## Root cause

The shortcut collapsed special light themes such as eyecare back to the canonical light theme when toggling from dark mode.

## Validation

- pnpm test
- pnpm lint
- pnpm build
