### PR TITLE
fix(terminal): sync agent terminal background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useMemo, useCallback, useRef } from "react";
 import { open as openDialog, confirm } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -268,7 +268,7 @@ function App() {
     return () => mediaQuery.removeEventListener("change", handleChange);
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const root = document.documentElement;
     // The midnight variant layers on top of the dark token set: it keeps the
     // `dark` class (so it inherits every dark token) and adds `midnight` for the

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -12,7 +12,8 @@ import {
 } from "../shortcuts";
 import type { TerminalFontSize, FontFamily, ThemeVariant } from "../types";
 import {
-  applyTerminalTheme,
+  themeFor,
+  minimumContrastRatioFor,
   initTerminal,
   loadWebglAddon,
   safeFit,
@@ -25,6 +26,21 @@ import {
 } from "./terminalShared";
 import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
 import "@xterm/xterm/css/xterm.css";
+
+function themeForAgentTerminal(variant: ThemeVariant, container: HTMLElement) {
+  const theme = themeFor(variant);
+  const background = window.getComputedStyle(container).getPropertyValue("--bg-panel").trim();
+  return background ? { ...theme, background } : theme;
+}
+
+function applyAgentTerminalTheme(
+  term: Terminal,
+  variant: ThemeVariant,
+  container: HTMLElement,
+): void {
+  term.options.theme = themeForAgentTerminal(variant, container);
+  term.options.minimumContrastRatio = minimumContrastRatioFor(variant);
+}
 
 interface TerminalViewProps {
   onInput: (data: string) => void;
@@ -92,6 +108,7 @@ export function TerminalView({
       terminalFontSize,
       monoFontFamily,
     );
+    applyAgentTerminalTheme(term, themeVariant, container);
     terminalRef.current = term;
     fitAddonRef.current = fitAddon;
     let disposed = false;
@@ -246,9 +263,8 @@ export function TerminalView({
   }, [isActive]);
 
   useEffect(() => {
-    if (terminalRef.current) {
-      applyTerminalTheme(terminalRef.current, themeVariant);
-    }
+    if (!terminalRef.current || !containerRef.current) return;
+    applyAgentTerminalTheme(terminalRef.current, themeVariant, containerRef.current);
   }, [themeVariant]);
 
   useEffect(() => {
@@ -291,6 +307,7 @@ export function TerminalView({
         height: "100%",
         overflow: "hidden",
         cursor: "text",
+        background: "inherit",
       }}
     />
   );


### PR DESCRIPTION
## Change Content

- Allow the intelligent agent dialog terminal to read the `--bg-panel` variable as the xterm background.

- Synchronize the terminal background during theme switching to avoid inconsistency between the terminal background and the current theme panel background.

- Use `useLayoutEffect` to update the root node's theme class name in advance, reducing visual flicker during theme switching.

## Impact

This change only affects the theme background synchronization of the intelligent agent terminal and does not alter the terminal input, output, or task execution logic.

## Verification

- `pnpm lint`

- `pnpm test`

- `pnpm build`

Build passed, Vite still outputs the existing chunk size warning.