### PR TITLE
feat(terminal): 添加工作树终端入口

### DIFF
--- a/src/components/ProjectPage.tsx
+++ b/src/components/ProjectPage.tsx
@@ -27,6 +27,7 @@ import { RightToolbar } from "./RightToolbar";
 import { TodoTaskView } from "./TodoTaskView";
 import { ShellTerminalPanel, type ShellTerminalPanelHandle } from "./ShellTerminalPanel";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { useToast } from "./Toast";
 import { useProjectPanels } from "../hooks/useProjectPanels";
 import { useI18n } from "../i18n";
 import s from "../styles";
@@ -160,6 +161,7 @@ export function ProjectPage({
   onExitSkillHub?: () => void;
 }) {
   const { t } = useI18n();
+  const { showToast } = useToast();
   const {
     rightPanel,
     openFiles,
@@ -186,6 +188,7 @@ export function ProjectPage({
   } = useProjectPanels();
 
   const [showShellTerminal, setShowShellTerminal] = useState(false);
+  const [shellProjectPath, setShellProjectPath] = useState(project.path);
   const [showSettings, setShowSettings] = useState(false);
   const [showFileSearch, setShowFileSearch] = useState(false);
   const [taskPanelCollapsed, setTaskPanelCollapsed] = useState(false);
@@ -252,14 +255,47 @@ export function ProjectPage({
     (target: string) => {
       const cmd = `make ${target}\n`;
       if (showShellTerminal && shellRef.current) {
-        shellRef.current.sendCommand(cmd);
+        const sent = shellRef.current.sendCommandToPath(project.path, cmd);
+        if (!sent) {
+          showToast(t("terminal.limitReachedWithCloseHint"), "warning");
+        }
       } else {
+        setShellProjectPath(project.path);
         pendingCmdRef.current = cmd;
         setShowShellTerminal(true);
       }
     },
-    [showShellTerminal],
+    [project.path, showShellTerminal, showToast, t],
   );
+
+  const handleOpenWorktreeTerminal = useCallback(
+    (worktreePath: string) => {
+      if (showShellTerminal && shellRef.current) {
+        const opened = shellRef.current.openPath(worktreePath);
+        if (!opened) {
+          showToast(t("terminal.limitReachedWithCloseHint"), "warning");
+        }
+        return;
+      }
+      setShellProjectPath(worktreePath);
+      setShowShellTerminal(true);
+    },
+    [showShellTerminal, showToast, t],
+  );
+
+  const handleToggleShellTerminal = useCallback(() => {
+    setShowShellTerminal((currentlyVisible) => {
+      if (!currentlyVisible) {
+        setShellProjectPath(project.path);
+      }
+      return !currentlyVisible;
+    });
+  }, [project.path]);
+
+  useEffect(() => {
+    if (showShellTerminal) return;
+    setShellProjectPath(project.path);
+  }, [project.id, project.path, showShellTerminal]);
 
   const handleShellReady = useCallback(() => {
     if (pendingCmdRef.current) {
@@ -267,6 +303,11 @@ export function ProjectPage({
       pendingCmdRef.current = null;
     }
   }, []);
+
+  const handleShellClose = useCallback(() => {
+    setShowShellTerminal(false);
+    setShellProjectPath(project.path);
+  }, [project.path]);
 
   const handleNewTask = useCallback(() => {
     clearFileAndDiff();
@@ -472,6 +513,8 @@ export function ProjectPage({
                 !!selectedTask &&
                 task.id === selectedTaskId &&
                 task.status !== "todo";
+              const worktreePath =
+                task.worktreePath && !task.worktreeDiscarded ? task.worktreePath : null;
               return (
                 <RunningView
                   key={task.id}
@@ -484,6 +527,9 @@ export function ProjectPage({
                   onResume={() => onResumeTask(task.id)}
                   onMergeWorktree={() => onMergeWorktree(task.id)}
                   onDiscardWorktree={() => onDiscardWorktree(task.id)}
+                  onOpenWorktreeTerminal={
+                    worktreePath ? () => handleOpenWorktreeTerminal(worktreePath) : undefined
+                  }
                   onReconnect={() => onReconnectTask(task.id)}
                   onMarkDone={() => onMarkTaskDone(task.id)}
                   onInput={(data) => onInput(task.id, data)}
@@ -505,10 +551,10 @@ export function ProjectPage({
         {showShellTerminal && (
           <ShellTerminalPanel
             ref={shellRef}
-            projectPath={project.path}
+            projectPath={shellProjectPath}
             projectId={project.id}
             isActive={visible}
-            onClose={() => setShowShellTerminal(false)}
+            onClose={handleShellClose}
             themeVariant={themeVariant}
             terminalFontSize={terminalFontSize}
             monoFontFamily={monoFontFamily}
@@ -571,7 +617,7 @@ export function ProjectPage({
         activePanel={rightPanel}
         onToggle={handleTogglePanel}
         terminalActive={showShellTerminal}
-        onToggleTerminal={() => setShowShellTerminal((v) => !v)}
+        onToggleTerminal={handleToggleShellTerminal}
         onOpenSearch={() => setShowFileSearch(true)}
         onOpenSettings={() => setShowSettings(true)}
       />

--- a/src/components/RunningView.tsx
+++ b/src/components/RunningView.tsx
@@ -31,6 +31,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   Download,
+  Terminal as TerminalIcon,
 } from "lucide-react";
 
 interface SessionMetrics {
@@ -92,6 +93,7 @@ export function RunningView({
   onResume,
   onMergeWorktree,
   onDiscardWorktree,
+  onOpenWorktreeTerminal,
   onReconnect,
   onMarkDone,
   onInput,
@@ -116,6 +118,7 @@ export function RunningView({
   onResume?: () => void;
   onMergeWorktree?: () => Promise<void>;
   onDiscardWorktree?: () => Promise<void>;
+  onOpenWorktreeTerminal?: () => void;
   onReconnect: () => void;
   onMarkDone: () => void;
   onInput: (data: string) => void;
@@ -423,6 +426,12 @@ export function RunningView({
         </div>
         {isActive && (
           <>
+            {task.worktreePath && !task.worktreeDiscarded && onOpenWorktreeTerminal && (
+              <button style={s.cancelBtn} onClick={onOpenWorktreeTerminal}>
+                <TerminalIcon size={12} strokeWidth={2.5} />
+                <span>{t("running.worktreeTerminal")}</span>
+              </button>
+            )}
             <button style={s.doneBtn} onClick={onMarkDone}>
               <CheckCircle2 size={12} strokeWidth={2.5} />
               <span>{t("running.markDone")}</span>

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -33,6 +33,8 @@ interface ShellOutputEvent {
 
 export interface ShellTerminalPanelHandle {
   sendCommand: (cmd: string) => void;
+  openPath: (projectPath: string) => boolean;
+  sendCommandToPath: (projectPath: string, cmd: string) => boolean;
 }
 
 interface ShellTerminalInstanceHandle {
@@ -42,6 +44,7 @@ interface ShellTerminalInstanceHandle {
 interface ShellSession {
   id: string;
   title: string;
+  projectPath: string;
 }
 
 interface Props {
@@ -59,10 +62,11 @@ interface Props {
 
 const MAX_SHELLS = 5;
 
-function createShellSession(projectId: string, index: number): ShellSession {
+function createShellSession(projectId: string, index: number, projectPath: string): ShellSession {
   return {
     id: `shell:${projectId}:${index}:${Date.now()}`,
     title: `Terminal ${index}`,
+    projectPath,
   };
 }
 
@@ -356,15 +360,52 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
     const { t } = useI18n();
     const initialShellRef = useRef<ShellSession | null>(null);
     if (!initialShellRef.current) {
-      initialShellRef.current = createShellSession(projectId, 1);
+      initialShellRef.current = createShellSession(projectId, 1, projectPath);
     }
 
     const nextShellIndexRef = useRef(2);
     const shellRefs = useRef<Record<string, ShellTerminalInstanceHandle | null>>({});
+    const pendingShellCommandsRef = useRef<Record<string, string[]>>({});
     const [shells, setShells] = useState<ShellSession[]>(() => [initialShellRef.current!]);
     const [activeShellId, setActiveShellId] = useState<string | null>(() => initialShellRef.current!.id);
+    const shellsRef = useRef(shells);
     const activeShellIdRef = useRef(activeShellId);
+    shellsRef.current = shells;
     activeShellIdRef.current = activeShellId;
+
+    const openPath = useCallback(
+      (nextProjectPath: string): string | null => {
+        const existingShell = shellsRef.current.find((shell) => shell.projectPath === nextProjectPath);
+        if (existingShell) {
+          setActiveShellId(existingShell.id);
+          return existingShell.id;
+        }
+
+        if (shellsRef.current.length >= MAX_SHELLS) return null;
+
+        const nextShell = createShellSession(projectId, nextShellIndexRef.current++, nextProjectPath);
+        const nextShells = [...shellsRef.current, nextShell];
+        shellsRef.current = nextShells;
+        setShells(nextShells);
+        setActiveShellId(nextShell.id);
+        return nextShell.id;
+      },
+      [projectId],
+    );
+
+    const handleShellReady = useCallback(
+      (shellId: string) => {
+        const pendingCommands = pendingShellCommandsRef.current[shellId];
+        if (pendingCommands?.length) {
+          delete pendingShellCommandsRef.current[shellId];
+          for (const cmd of pendingCommands) {
+            shellRefs.current[shellId]?.sendCommand(cmd);
+          }
+        }
+        onReady?.();
+      },
+      [onReady],
+    );
 
     useImperativeHandle(
       ref,
@@ -374,16 +415,33 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
           if (!currentShellId) return;
           shellRefs.current[currentShellId]?.sendCommand(cmd);
         },
+        openPath: (nextProjectPath: string) => {
+          return openPath(nextProjectPath) !== null;
+        },
+        sendCommandToPath: (nextProjectPath: string, cmd: string) => {
+          const shellId = openPath(nextProjectPath);
+          if (!shellId) return false;
+          const shell = shellRefs.current[shellId];
+          if (shell) {
+            shell.sendCommand(cmd);
+            return true;
+          }
+          pendingShellCommandsRef.current[shellId] = [
+            ...(pendingShellCommandsRef.current[shellId] ?? []),
+            cmd,
+          ];
+          return true;
+        },
       }),
-      [],
+      [openPath],
     );
 
     const handleAddShell = useCallback(() => {
       if (shells.length >= MAX_SHELLS) return;
-      const nextShell = createShellSession(projectId, nextShellIndexRef.current++);
+      const nextShell = createShellSession(projectId, nextShellIndexRef.current++, projectPath);
       setShells((prev) => [...prev, nextShell]);
       setActiveShellId(nextShell.id);
-    }, [projectId, shells.length]);
+    }, [projectId, projectPath, shells.length]);
 
     const handleCloseShell = useCallback(
       (shellId: string) => {
@@ -391,8 +449,10 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
         if (closingIndex === -1) return;
 
         const nextShells = shells.filter((shell) => shell.id !== shellId);
+        shellsRef.current = nextShells;
         setShells(nextShells);
         delete shellRefs.current[shellId];
+        delete pendingShellCommandsRef.current[shellId];
 
         if (nextShells.length === 0) {
           onClose();
@@ -477,12 +537,12 @@ export const ShellTerminalPanel = forwardRef<ShellTerminalPanelHandle, Props>(
                   shellRefs.current[shell.id] = instance;
                 }}
                 shellId={shell.id}
-                projectPath={projectPath}
+                projectPath={shell.projectPath}
                 isActive={isActive && activeShellId === shell.id}
                 themeVariant={themeVariant}
                 terminalFontSize={terminalFontSize}
                 monoFontFamily={monoFontFamily}
-                onReady={onReady}
+                onReady={() => handleShellReady(shell.id)}
               />
             ))}
           </div>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -440,6 +440,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "terminal.title": "Terminal",
     "terminal.closeTerminals": "Close terminals",
     "terminal.limitReached": "Terminal limit reached",
+    "terminal.limitReachedWithCloseHint": "Terminal limit reached. Close one terminal first.",
     "terminal.newTerminal": "New terminal",
     "terminal.closeShell": "Close {title}",
     "running.cancel": "Cancel",
@@ -453,6 +454,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "running.reconnectTask": "Reconnect task",
     "running.cancelTask": "Cancel task",
     "running.markDone": "Mark completed",
+    "running.worktreeTerminal": "Worktree terminal",
     "running.resumeUnavailable": "This task has no session ID, so it cannot be resumed.",
     "running.detachedTitle": "Terminal connection lost",
     "running.detachedNoSession":
@@ -936,6 +938,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "terminal.title": "终端",
     "terminal.closeTerminals": "关闭终端",
     "terminal.limitReached": "终端数量已达上限",
+    "terminal.limitReachedWithCloseHint": "终端数量已达上限，请先关闭一个终端。",
     "terminal.newTerminal": "新建终端",
     "terminal.closeShell": "关闭 {title}",
     "running.cancel": "取消",
@@ -949,6 +952,7 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "running.reconnectTask": "重新连接",
     "running.cancelTask": "取消任务",
     "running.markDone": "标记已完成",
+    "running.worktreeTerminal": "工作树终端",
     "running.resumeUnavailable": "这个任务没有保存会话 ID，无法恢复。",
     "running.detachedTitle": "终端连接已断开",
     "running.detachedNoSession":


### PR DESCRIPTION
## 变更内容

- 在运行中任务顶部为有效工作树任务新增“工作树终端”入口。
- Shell 终端面板支持按项目路径打开或复用终端实例，可直接切换到任务工作树目录。
- `make` 目标快捷运行改为发送到项目根目录终端，避免误发到工作树终端。
- 关闭终端面板或普通入口重新打开时，默认恢复为项目根目录终端。

## 影响

有工作树且未丢弃的任务会显示工作树终端按钮，点击后在右侧 Shell 面板中打开对应工作树目录。普通终端入口仍默认打开项目根目录。

## 验证

- `pnpm lint`
- `pnpm test`
- `pnpm build`

构建通过，Vite 仍输出现有的 chunk size warning。