### PR TITLE
feat(terminal): auto-hide xterm scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -300,13 +300,17 @@ body {
 }
 
 .nezha-xterm-host {
-  --xterm-scrollbar-edge-offset: 0px;
+  --xterm-scrollbar-width: 12px;
   --xterm-scrollbar-thumb: rgba(126, 136, 153, 0.48);
   --xterm-scrollbar-thumb-hover: rgba(148, 158, 176, 0.68);
 }
 
-.nezha-xterm-host.nezha-shell-xterm-host {
-  --xterm-scrollbar-edge-offset: 6px;
+.nezha-xterm-host .xterm .xterm-screen {
+  margin-right: var(--xterm-scrollbar-width);
+}
+
+.nezha-xterm-host:not(.nezha-shell-xterm-host) .xterm-screen {
+  margin-left: auto;
 }
 
 .nezha-xterm-host .xterm .xterm-viewport {
@@ -327,10 +331,10 @@ body {
 }
 
 .nezha-xterm-host .xterm .xterm-scrollable-element > .scrollbar.vertical {
-  width: 12px !important;
-  right: calc(-1 * var(--xterm-scrollbar-edge-offset)) !important;
+  width: var(--xterm-scrollbar-width) !important;
+  right: 0 !important;
   background: transparent !important;
-  transition: opacity 140ms ease-out;
+  pointer-events: auto !important;
 }
 
 .nezha-xterm-host .xterm .xterm-scrollable-element > .scrollbar.vertical.invisible.fade {
@@ -343,6 +347,14 @@ body {
   width: 6px !important;
   border-radius: 999px;
   background: var(--xterm-scrollbar-thumb) !important;
+  opacity: 0;
+  transition: opacity 140ms ease-out, background 140ms ease-out;
+}
+
+.nezha-xterm-host.nezha-xterm-scrolling .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider,
+.nezha-xterm-host .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider:hover,
+.nezha-xterm-host .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider.active {
+  opacity: 1;
 }
 
 .nezha-xterm-host .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider:hover,

--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -13,6 +13,7 @@ import {
   safeFit,
   createSmartWriter,
   attachMacWebKitTerminalGuard,
+  attachTerminalScrollbarAutoHide,
   applyTerminalFontSize,
   applyTerminalFontFamily,
 } from "./terminalShared";
@@ -110,6 +111,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       terminalRef.current = term;
       fitAddonRef.current = fitAddon;
       term.open(container);
+      const disposeScrollbarAutoHide = attachTerminalScrollbarAutoHide(term, container);
       const disposeInputFix = attachMacWebKitShiftInputFix(term);
       loadWebglAddon(term);
       const writer = createSmartWriter(term);
@@ -203,6 +205,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         terminalRef.current = null;
         fitAddonRef.current = null;
+        disposeScrollbarAutoHide();
         disposeMacWebKitGuard();
         disposeInputFix();
         term.dispose();
@@ -270,7 +273,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
           position: "absolute",
           inset: 0,
           overflow: "hidden",
-          padding: "4px 6px",
+          padding: "4px 0 4px 6px",
           cursor: "text",
           visibility: isActive ? "visible" : "hidden",
           pointerEvents: isActive ? "auto" : "none",

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -18,6 +18,7 @@ import {
   safeFit,
   createSmartWriter,
   attachMacWebKitTerminalGuard,
+  attachTerminalScrollbarAutoHide,
   applyTerminalFontSize,
   applyTerminalFontFamily,
 } from "./terminalShared";
@@ -91,6 +92,7 @@ export function TerminalView({
     const serializeAddon = new SerializeAddon();
     term.loadAddon(serializeAddon);
     term.open(container);
+    const disposeScrollbarAutoHide = attachTerminalScrollbarAutoHide(term, container);
     const disposeInputFix = attachMacWebKitShiftInputFix(term);
     loadWebglAddon(term);
 
@@ -176,6 +178,7 @@ export function TerminalView({
       }
       onRegisterRef.current(null);
       fitAddonRef.current = null;
+      disposeScrollbarAutoHide();
       disposeMacWebKitGuard();
       disposeInputFix();
       disposeSmartCopy();

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -5,9 +5,9 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { IS_MAC_WEBKIT } from "../platform";
 import type { ThemeVariant } from "../types";
 
-// xterm 6 的自绘滚动条宽度由 overviewRuler.width 复用控制；保持 1px 预留，
-// 视觉宽度和贴边效果由 App.css 中的 .nezha-xterm-host 覆盖完成。
-const XTERM_OVERLAY_SCROLLBAR_WIDTH = 1;
+// xterm 6 的自绘滚动条宽度由 overviewRuler.width 复用控制；FitAddon 会用它
+// 计算可用列数，因此必须和 App.css 中的滚动条槽宽保持一致。
+const XTERM_SCROLLBAR_WIDTH = 12;
 
 // ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -326,7 +326,7 @@ export function initTerminal(
     fontSize,
     theme: themeFor(variant),
     allowProposedApi: true,
-    overviewRuler: { width: XTERM_OVERLAY_SCROLLBAR_WIDTH },
+    overviewRuler: { width: XTERM_SCROLLBAR_WIDTH },
     // 当运行中的 TUI（Claude Code / Codex）开启鼠标上报时，xterm 默认把拖动当作
     // 鼠标事件转发给程序并取消本地选区，导致 macOS 用户"运行时无法框选"。开启此项后
     // 按住 ⌥ Option 拖动可强制本地选区（iTerm2 / Terminal.app 的标准约定）。
@@ -340,6 +340,38 @@ export function initTerminal(
   term.unicode.activeVersion = "11";
 
   return { term, fitAddon };
+}
+
+export function attachTerminalScrollbarAutoHide(term: Terminal, container: HTMLElement): () => void {
+  const ownerWindow = container.ownerDocument.defaultView ?? window;
+  let scrollHideTimer: number | null = null;
+
+  const clearScrollHideTimer = () => {
+    if (scrollHideTimer === null) return;
+    ownerWindow.clearTimeout(scrollHideTimer);
+    scrollHideTimer = null;
+  };
+
+  const hideAfterScroll = () => {
+    clearScrollHideTimer();
+    scrollHideTimer = ownerWindow.setTimeout(() => {
+      container.classList.remove("nezha-xterm-scrolling");
+      scrollHideTimer = null;
+    }, 700);
+  };
+
+  const handleScroll = () => {
+    container.classList.add("nezha-xterm-scrolling");
+    hideAfterScroll();
+  };
+
+  const scrollDisposable = term.onScroll(handleScroll);
+
+  return () => {
+    clearScrollHideTimer();
+    container.classList.remove("nezha-xterm-scrolling");
+    scrollDisposable.dispose();
+  };
 }
 
 /**

--- a/src/styles/terminal.ts
+++ b/src/styles/terminal.ts
@@ -74,7 +74,7 @@ export const terminal = {
     cursor: "pointer",
     flexShrink: 0,
   },
-  terminalContainer: { flex: 1, overflow: "hidden" as const, padding: "14px 16px 16px" },
+  terminalContainer: { flex: 1, overflow: "hidden" as const, padding: "10px 0 10px 10px" },
   interruptedSessionWrap: {
     flex: 1,
     minHeight: 0,


### PR DESCRIPTION
## 变更内容
- 为 xterm 终端增加滚动条自动显隐逻辑，滚动、悬停或拖动时显示，空闲后隐藏。
- 将自动显隐能力接入任务终端和嵌入式 Shell 终端。
- 调整终端滚动条样式、任务终端居中显示与终端容器边距。

## 影响
- 减少终端区域常驻滚动条的视觉干扰，同时保留滚动和拖动时的可操作性。
- 任务终端与 Shell 终端共享同一套滚动条行为，避免交互差异。

## 验证
- pnpm lint
- NODE_OPTIONS="--localstorage-file=/tmp/nezha-vitest-localstorage-auto-hide.json" pnpm test
- pnpm build（通过，仍有既有 Vite chunk size 警告）