### PR TITLE
fix(project drawer)project rail drawer toggle

### DIFF
--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -412,7 +412,9 @@ export function ProjectRail({
         <>
           <button
             title={t("project.showAllProjects")}
+            aria-expanded={drawerOpen}
             onClick={() => setDrawerOpen((v) => !v)}
+            onMouseDown={(e) => e.stopPropagation()}
             onMouseEnter={() => setExpandHov(true)}
             onMouseLeave={() => setExpandHov(false)}
             style={{

--- a/src/test/project-rail.test.tsx
+++ b/src/test/project-rail.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { I18nProvider } from "../i18n";
+import { ProjectRail } from "../components/ProjectRail";
+import type { Project } from "../types";
+
+const projects: Project[] = [
+  {
+    id: "project-1",
+    name: "Alpha",
+    path: "/tmp/alpha",
+    lastOpenedAt: 1,
+  },
+  {
+    id: "project-2",
+    name: "Beta",
+    path: "/tmp/beta",
+    lastOpenedAt: 2,
+  },
+];
+
+function renderRail() {
+  return render(
+    <I18nProvider>
+      <ProjectRail
+        projects={projects}
+        allTasks={[]}
+        activeProjectId="project-1"
+        onSwitch={() => undefined}
+        onOpen={() => undefined}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("ProjectRail", () => {
+  test("toggles the project drawer closed when clicking the expand button again", async () => {
+    const user = userEvent.setup();
+    renderRail();
+
+    const toggle = screen.getByRole("button", { name: "Show all projects" });
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByPlaceholderText("Search projects")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByPlaceholderText("Search projects")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix the project rail drawer toggle so clicking the double-chevron again closes the drawer.
- Add a regression test for the open-then-close interaction.

## Root Cause

The drawer listens for outside clicks on `mousedown`. When the drawer was open, clicking the rail toggle first triggered that outside-click handler, closing the drawer, then the button `click` handler toggled it open again.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
