### PR TITLE
feat(search): add C/C++ file type filter

### DIFF
--- a/src/components/file-explorer/SearchPanel.tsx
+++ b/src/components/file-explorer/SearchPanel.tsx
@@ -24,6 +24,7 @@ const FILE_FILTERS: FileFilter[] = [
   { id: "rust", label: "Rust", extensions: ["rs"] },
   { id: "py", label: "Python", extensions: ["py"] },
   { id: "go", label: "Go", extensions: ["go"] },
+  { id: "cpp", label: "C/C++", extensions: ["c", "h", "cpp", "cc", "cxx", "hpp", "hh", "hxx"] },
   { id: "web", label: "Web", extensions: ["html", "css", "scss"] },
   { id: "json", label: "JSON", extensions: ["json", "jsonc"] },
   { id: "yaml", label: "YAML", extensions: ["yml", "yaml"] },


### PR DESCRIPTION
## What

The file search panel's **type filter** (`FILE_FILTERS` in `src/components/file-explorer/SearchPanel.tsx`) offered TS, JS, Rust, Python, Go, Web, JSON, YAML, Markdown, config and images — but had **no option for C/C++**.

This adds a **C/C++** filter covering the common source and header extensions:

```
c · h · cpp · cc · cxx · hpp · hh · hxx
```

placed next to the other compiled-language filters (after Go).

## Notes

- One-line addition to the existing `FILE_FILTERS` array; uses a plain `label` like the other code-language entries, so no new i18n keys are needed.
- The file viewer's *syntax highlighting* already handles C/C++ — this only fills the gap in the *search type filter*.
