### PR TITLE
[codex] fix file explorer context menu edge positioning

### DIFF
--- a/src/components/file-explorer/ContextMenu.tsx
+++ b/src/components/file-explorer/ContextMenu.tsx
@@ -1,6 +1,9 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import s from "../../styles";
 import { useI18n } from "../../i18n";
 import type { ContextMenuState } from "./types";
+
+const VIEWPORT_MARGIN = 8;
 
 export function FileExplorerContextMenu({
   ctxMenu,
@@ -20,6 +23,34 @@ export function FileExplorerContextMenu({
   onCopyPath: (e: React.MouseEvent, path: string, withAt: boolean) => void;
 }) {
   const { t } = useI18n();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({ x: ctxMenu.x, y: ctxMenu.y });
+
+  const updatePosition = useCallback(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const rect = menu.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+    const viewportHeight = document.documentElement.clientHeight || window.innerHeight;
+    const maxX = Math.max(VIEWPORT_MARGIN, viewportWidth - rect.width - VIEWPORT_MARGIN);
+    const maxY = Math.max(VIEWPORT_MARGIN, viewportHeight - rect.height - VIEWPORT_MARGIN);
+
+    setPosition({
+      x: Math.min(Math.max(ctxMenu.x, VIEWPORT_MARGIN), maxX),
+      y: Math.min(Math.max(ctxMenu.y, VIEWPORT_MARGIN), maxY),
+    });
+  }, [ctxMenu.x, ctxMenu.y]);
+
+  useLayoutEffect(() => {
+    setPosition({ x: ctxMenu.x, y: ctxMenu.y });
+    updatePosition();
+  }, [ctxMenu.x, ctxMenu.y, updatePosition]);
+
+  useLayoutEffect(() => {
+    window.addEventListener("resize", updatePosition);
+    return () => window.removeEventListener("resize", updatePosition);
+  }, [updatePosition]);
 
   const items = [
     { label: t("file.newFile"), action: "newFile" },
@@ -47,7 +78,8 @@ export function FileExplorerContextMenu({
         }}
       />
       <div
-        style={{ ...s.fileCtxMenu, left: ctxMenu.x, top: ctxMenu.y }}
+        ref={menuRef}
+        style={{ ...s.fileCtxMenu, left: position.x, top: position.y }}
         onClick={(e) => e.stopPropagation()}
         onContextMenu={(e) => {
           e.preventDefault();

--- a/src/test/file-explorer-context-menu.test.tsx
+++ b/src/test/file-explorer-context-menu.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileExplorerContextMenu } from "../components/file-explorer/ContextMenu";
+import { I18nProvider } from "../i18n";
+
+const noop = () => {};
+
+function renderMenu(x: number, y: number) {
+  return render(
+    <I18nProvider>
+      <FileExplorerContextMenu
+        ctxMenu={{
+          x,
+          y,
+          path: "/project/src/App.tsx",
+          isDir: false,
+          isRoot: false,
+        }}
+        onClose={noop}
+        onNewFile={noop}
+        onNewFolder={noop}
+        onDelete={noop}
+        onOpenInSystem={noop}
+        onCopyPath={noop}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("FileExplorerContextMenu", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the menu inside the viewport when opened near the bottom-right edge", () => {
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(document.documentElement, "clientHeight", {
+      configurable: true,
+      value: 240,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 180,
+      bottom: 210,
+      width: 180,
+      height: 210,
+      toJSON: () => ({}),
+    });
+
+    renderMenu(315, 235);
+
+    const menu = screen.getByRole("button", { name: "New File" }).parentElement;
+
+    expect(menu).toHaveStyle({ left: "132px", top: "22px" });
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the file explorer context menu inside the visible viewport when opened near app edges.
- Recalculate the clamped position after menu measurement and window resize.
- Add a regression test for the bottom-right overflow case.

## Root Cause

The file explorer context menu used the raw right-click `clientX` and `clientY` as fixed `left` and `top` coordinates without accounting for the rendered menu size or viewport bounds.

## Validation

- `pnpm vitest run src/test/file-explorer-context-menu.test.tsx`
- `pnpm test`
- `pnpm build`
- `pnpm lint`
