### PR TITLE
fix(font): apply Windows mono default reliably

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,8 @@ import {
 } from "./types";
 import {
   DEFAULT_UI_FONT,
-  DEFAULT_MONO_FONT,
+  getDefaultMonoFont,
+  isAutoDefaultMonoFont,
 } from "./types";
 import type { FontFamily } from "./types";
 import { quoteFontName } from "./utils/fonts";
@@ -175,6 +176,12 @@ function getInitialAttentionBadge(): boolean {
 function getInitialFontFamily(key: string, fallback: FontFamily): FontFamily {
   const stored = localStorage.getItem(key);
   if (!stored) return fallback;
+  // 老版本 useEffect 无差别把当时的 DEFAULT_MONO_FONT 写进 localStorage,
+  // 导致默认更新对老用户无效。识别到历史自动默认值就清掉,改用当前平台默认。
+  if (key === "nezha:monoFontFamily" && isAutoDefaultMonoFont(stored)) {
+    localStorage.removeItem(key);
+    return fallback;
+  }
   // 旧版本写入的裸字体名（如 "Maple Mono NF CN"）在 Canvas 2D 下会被
   // tokenize 成多个 family 全部 miss；读出时统一 normalize 一次。
   return quoteFontName(stored);
@@ -198,7 +205,7 @@ function App() {
     getInitialFontFamily("nezha:uiFontFamily", DEFAULT_UI_FONT),
   );
   const [monoFontFamily, setMonoFontFamily] = useState<FontFamily>(() =>
-    getInitialFontFamily("nezha:monoFontFamily", DEFAULT_MONO_FONT),
+    getInitialFontFamily("nezha:monoFontFamily", getDefaultMonoFont()),
   );
   const [projects, setProjects] = useState<Project[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -332,9 +339,16 @@ function App() {
   }, [uiFontFamily]);
 
   useEffect(() => {
-    const value = monoFontFamily.trim() || DEFAULT_MONO_FONT;
-    localStorage.setItem("nezha:monoFontFamily", value);
-    document.documentElement.style.setProperty("--font-mono", value);
+    const trimmed = monoFontFamily.trim();
+    const effective = trimmed || getDefaultMonoFont();
+    // 用户没显式自定义时不写入 localStorage,避免把默认值固化、
+    // 导致后续改默认对老用户失效（这正是历史 bug 的根因）。
+    if (!trimmed || isAutoDefaultMonoFont(trimmed)) {
+      localStorage.removeItem("nezha:monoFontFamily");
+    } else {
+      localStorage.setItem("nezha:monoFontFamily", trimmed);
+    }
+    document.documentElement.style.setProperty("--font-mono", effective);
   }, [monoFontFamily]);
 
   const handleToggleTheme = useCallback(() => {

--- a/src/components/app-settings/FontPanel.tsx
+++ b/src/components/app-settings/FontPanel.tsx
@@ -6,7 +6,7 @@ import {
   TERMINAL_FONT_SIZE_STEP,
   clampTerminalFontSize,
   DEFAULT_UI_FONT,
-  DEFAULT_MONO_FONT,
+  getDefaultMonoFont,
 } from "../../types";
 import { useI18n } from "../../i18n";
 import s from "../../styles";
@@ -130,7 +130,7 @@ export function FontPanel({
         onChange={setPendingMonoFont}
         label={t("font.monoFontFamily")}
         hint={t("font.monoFontFamilyHint")}
-        defaultFont={DEFAULT_MONO_FONT}
+        defaultFont={getDefaultMonoFont()}
         preview={(
           <div style={s.fontInlinePreview}>
             <div style={s.fontPreviewHeaderRow}>

--- a/src/components/app-settings/FontSelector.tsx
+++ b/src/components/app-settings/FontSelector.tsx
@@ -73,7 +73,6 @@ export function FontSelector({ value, onChange, label, hint, defaultFont, previe
   }, [open, loaded, value, filtered]);
 
   const displayName = parseFirstFontName(value);
-  const isDefaultFont = value === defaultFont;
 
   const handleSelect = useCallback(
     (font: string) => {
@@ -113,13 +112,8 @@ export function FontSelector({ value, onChange, label, hint, defaultFont, previe
             </span>
             <button
               type="button"
-              disabled={isDefaultFont}
               onClick={() => onChange(defaultFont)}
-              style={{
-                ...s.fontSelectorResetBtn,
-                opacity: isDefaultFont ? 0.45 : 1,
-                cursor: isDefaultFont ? "default" : "pointer",
-              }}
+              style={s.fontSelectorResetBtn}
             >
               <RotateCcw size={11} />
               {t("common.reset")}

--- a/src/components/app-settings/FontSelector.tsx
+++ b/src/components/app-settings/FontSelector.tsx
@@ -73,6 +73,7 @@ export function FontSelector({ value, onChange, label, hint, defaultFont, previe
   }, [open, loaded, value, filtered]);
 
   const displayName = parseFirstFontName(value);
+  const isDefaultFont = value === defaultFont;
 
   const handleSelect = useCallback(
     (font: string) => {
@@ -112,10 +113,12 @@ export function FontSelector({ value, onChange, label, hint, defaultFont, previe
             </span>
             <button
               type="button"
+              disabled={isDefaultFont}
               onClick={() => onChange(defaultFont)}
               style={{
                 ...s.fontSelectorResetBtn,
-                visibility: value !== defaultFont ? "visible" : "hidden",
+                opacity: isDefaultFont ? 0.45 : 1,
+                cursor: isDefaultFont ? "default" : "pointer",
               }}
             >
               <RotateCcw size={11} />

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -134,7 +134,7 @@
   --radius-lg: 12px;
 
   --font-ui: "SF Pro Display", "IBM Plex Sans", "PingFang SC", "Noto Sans SC", sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace;
 }
 
 /* Design tokens: eye-care theme (warm sepia, low-contrast) */

--- a/src/test/font-defaults.test.ts
+++ b/src/test/font-defaults.test.ts
@@ -6,15 +6,13 @@ describe("font defaults", () => {
     vi.unstubAllGlobals();
   });
 
-  test("uses the Windows mono stack on Windows user agents", () => {
+  test("uses Consolas as the Windows mono default", () => {
     vi.stubGlobal("navigator", {
       userAgent:
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36",
     });
 
-    expect(getDefaultMonoFont()).toBe(
-      'Consolas, "Cascadia Mono", "JetBrains Mono", "Fira Code", monospace',
-    );
+    expect(getDefaultMonoFont()).toBe("Consolas");
   });
 
   test("treats every auto default stack as replaceable", () => {
@@ -25,6 +23,9 @@ describe("font defaults", () => {
       isAutoDefaultMonoFont(
         '"JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace',
       ),
+    ).toBe(true);
+    expect(
+      isAutoDefaultMonoFont('Consolas, "Cascadia Mono", "JetBrains Mono", "Fira Code", monospace'),
     ).toBe(true);
     expect(isAutoDefaultMonoFont('"JetBrains Mono"')).toBe(false);
   });

--- a/src/test/font-defaults.test.ts
+++ b/src/test/font-defaults.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getDefaultMonoFont, isAutoDefaultMonoFont } from "../types";
+
+describe("font defaults", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("uses the Windows mono stack on Windows user agents", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36",
+    });
+
+    expect(getDefaultMonoFont()).toBe(
+      'Consolas, "Cascadia Mono", "JetBrains Mono", "Fira Code", monospace',
+    );
+  });
+
+  test("treats every auto default stack as replaceable", () => {
+    expect(
+      isAutoDefaultMonoFont('"JetBrains Mono", "Fira Code", ui-monospace, monospace'),
+    ).toBe(true);
+    expect(
+      isAutoDefaultMonoFont(
+        '"JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace',
+      ),
+    ).toBe(true);
+    expect(isAutoDefaultMonoFont('"JetBrains Mono"')).toBe(false);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ const MONO_FONT_LINUX: FontFamily =
   '"JetBrains Mono", "Fira Code", "DejaVu Sans Mono", "Liberation Mono", ui-monospace, monospace';
 const MONO_FONT_FALLBACK: FontFamily =
   '"JetBrains Mono", "Fira Code", ui-monospace, monospace';
+const MONO_FONT_PR326_INITIAL_FALLBACK: FontFamily =
+  '"JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace';
 
 export function getDefaultMonoFont(): FontFamily {
   if (typeof navigator === "undefined") return MONO_FONT_FALLBACK;
@@ -68,6 +70,7 @@ const LEGACY_AUTO_MONO_FONTS: ReadonlySet<string> = new Set([
   MONO_FONT_WINDOWS,
   MONO_FONT_MAC,
   MONO_FONT_LINUX,
+  MONO_FONT_PR326_INITIAL_FALLBACK,
 ]);
 
 export function isAutoDefaultMonoFont(value: string): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,8 +41,38 @@ export function clampTerminalFontSize(value: number): TerminalFontSize {
 export type FontFamily = string;
 export const DEFAULT_UI_FONT: FontFamily =
   '"SF Pro Display", "IBM Plex Sans", "PingFang SC", "Noto Sans SC", sans-serif';
-export const DEFAULT_MONO_FONT: FontFamily =
-  '"JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace';
+
+const MONO_FONT_WINDOWS: FontFamily =
+  'Consolas, "Cascadia Mono", "JetBrains Mono", "Fira Code", monospace';
+const MONO_FONT_MAC: FontFamily =
+  '"JetBrains Mono", "Fira Code", "SF Mono", Menlo, ui-monospace, monospace';
+const MONO_FONT_LINUX: FontFamily =
+  '"JetBrains Mono", "Fira Code", "DejaVu Sans Mono", "Liberation Mono", ui-monospace, monospace';
+const MONO_FONT_FALLBACK: FontFamily =
+  '"JetBrains Mono", "Fira Code", ui-monospace, monospace';
+
+export function getDefaultMonoFont(): FontFamily {
+  if (typeof navigator === "undefined") return MONO_FONT_FALLBACK;
+  const ua = navigator.userAgent;
+  if (/Windows/i.test(ua)) return MONO_FONT_WINDOWS;
+  if (/Mac OS X|Macintosh/i.test(ua)) return MONO_FONT_MAC;
+  if (/Linux/i.test(ua)) return MONO_FONT_LINUX;
+  return MONO_FONT_FALLBACK;
+}
+
+// 老版本 App.tsx 的 useEffect 无差别把当时的默认 mono 字体也写进 localStorage,
+// 导致后续改默认对老用户失效。所有"曾经作为自动默认值出现过"的字符串都视为
+// "用户未自定义",在 getInitialFontFamily 里清掉后回退到当前平台默认。
+const LEGACY_AUTO_MONO_FONTS: ReadonlySet<string> = new Set([
+  MONO_FONT_FALLBACK,
+  MONO_FONT_WINDOWS,
+  MONO_FONT_MAC,
+  MONO_FONT_LINUX,
+]);
+
+export function isAutoDefaultMonoFont(value: string): boolean {
+  return LEGACY_AUTO_MONO_FONTS.has(value.trim());
+}
 
 export type TaskStatus =
   | "todo"

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export type FontFamily = string;
 export const DEFAULT_UI_FONT: FontFamily =
   '"SF Pro Display", "IBM Plex Sans", "PingFang SC", "Noto Sans SC", sans-serif';
 export const DEFAULT_MONO_FONT: FontFamily =
-  '"JetBrains Mono", "Fira Code", ui-monospace, monospace';
+  '"JetBrains Mono", "Fira Code", "Cascadia Mono", Consolas, "SF Mono", Menlo, ui-monospace, monospace';
 
 export type TaskStatus =
   | "todo"

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,8 @@ export type FontFamily = string;
 export const DEFAULT_UI_FONT: FontFamily =
   '"SF Pro Display", "IBM Plex Sans", "PingFang SC", "Noto Sans SC", sans-serif';
 
-const MONO_FONT_WINDOWS: FontFamily =
+const MONO_FONT_WINDOWS: FontFamily = "Consolas";
+const MONO_FONT_WINDOWS_STACK: FontFamily =
   'Consolas, "Cascadia Mono", "JetBrains Mono", "Fira Code", monospace';
 const MONO_FONT_MAC: FontFamily =
   '"JetBrains Mono", "Fira Code", "SF Mono", Menlo, ui-monospace, monospace';
@@ -68,6 +69,7 @@ export function getDefaultMonoFont(): FontFamily {
 const LEGACY_AUTO_MONO_FONTS: ReadonlySet<string> = new Set([
   MONO_FONT_FALLBACK,
   MONO_FONT_WINDOWS,
+  MONO_FONT_WINDOWS_STACK,
   MONO_FONT_MAC,
   MONO_FONT_LINUX,
   MONO_FONT_PR326_INITIAL_FALLBACK,


### PR DESCRIPTION
## Summary

- use plain `Consolas` as the Windows default mono font instead of a multi-font stack
- treat previous auto default mono stacks as legacy values so they do not stay pinned in localStorage
- keep the font reset action visible and clickable so users can re-apply the platform default
- add regression coverage for Windows mono defaults and legacy default detection

## Root Cause

The previous default font value could be persisted into `nezha:monoFontFamily`, so changing the platform default later did not affect users who already had an auto-written default in localStorage.

On Windows, manually selecting `Consolas` rendered correctly, while resetting to the default font stack still rendered like JetBrains Mono. Using the single `Consolas` family for the Windows default makes reset follow the same working path as manual selection.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- verified on Windows that reset applies Consolas correctly
