### PR TITLE
fix(fs): reliably reveal files in Windows Explorer

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -238,47 +238,76 @@ fn previewable_image_mime_type(path: &Path) -> Option<&'static str> {
 
 #[tauri::command]
 pub async fn open_in_system_file_manager(path: String, project_path: String) -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(move || {
+    tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let target = validate_path_within(&path, &project_path, true)?;
         let is_dir = target.is_dir();
 
         #[cfg(target_os = "macos")]
-        let status = {
+        {
             let mut command = Command::new("open");
             if is_dir {
                 command.arg(&target);
             } else {
                 command.arg("-R").arg(&target);
             }
-            command.status()
-        };
+            let status = command
+                .status()
+                .map_err(|e| format!("Failed to launch system file manager: {}", e))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!("System file manager exited with status {}", status))
+            }
+        }
 
         #[cfg(target_os = "windows")]
-        let status = {
+        {
+            // `validate_path_within` canonicalizes the path, which on Windows yields a
+            // `\\?\` verbatim prefix that explorer.exe cannot parse for `/select`.
+            // Strip it back to a plain path so the file is actually highlighted —
+            // `\\?\UNC\server\share` (network / WSL paths) must become `\\server\share`,
+            // and `\\?\C:\dir` must become `C:\dir`.
+            let display = target.to_string_lossy();
+            let plain: std::borrow::Cow<str> = if let Some(rest) = display.strip_prefix(r"\\?\UNC\")
+            {
+                std::borrow::Cow::Owned(format!(r"\\{}", rest))
+            } else if let Some(rest) = display.strip_prefix(r"\\?\") {
+                std::borrow::Cow::Borrowed(rest)
+            } else {
+                std::borrow::Cow::Borrowed(display.as_ref())
+            };
+            let plain: &str = &plain;
             let mut command = Command::new("explorer");
             if is_dir {
-                command.arg(&target);
+                command.arg(plain);
             } else {
-                command.arg(format!("/select,{}", target.display()));
+                command.arg(format!("/select,{}", plain));
             }
-            command.status()
-        };
+            // explorer.exe returns exit code 1 even when it successfully opens a
+            // window, so its exit status is not a reliable failure signal —
+            // a successful launch is all we can meaningfully report on.
+            command
+                .status()
+                .map_err(|e| format!("Failed to launch system file manager: {}", e))?;
+            Ok(())
+        }
 
         #[cfg(all(unix, not(target_os = "macos")))]
-        let status = {
+        {
             let folder = if is_dir {
                 target.as_path()
             } else {
                 target.parent().ok_or_else(|| "Cannot resolve parent directory".to_string())?
             };
-            Command::new("xdg-open").arg(folder).status()
-        };
-
-        let status = status.map_err(|e| format!("Failed to launch system file manager: {}", e))?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err(format!("System file manager exited with status {}", status))
+            let status = Command::new("xdg-open")
+                .arg(folder)
+                .status()
+                .map_err(|e| format!("Failed to launch system file manager: {}", e))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!("System file manager exited with status {}", status))
+            }
         }
     })
     .await


### PR DESCRIPTION
## 问题

Windows 10/11 下,在文件栏右键某个**文件** → "在系统文件夹中打开",会弹出错误:

> 在系统文件夹中打开失败:System file manager exited with status exit code: 1

但资源管理器实际上是打开了的(只是没能正确选中目标文件)。

## 根因

`open_in_system_file_manager`(`src-tauri/src/fs.rs`)在 Windows 分支存在两个叠加问题:

1. **`\\?\` verbatim 前缀**:`validate_path_within` 用 `Path::canonicalize()` 解析路径,Windows 上返回带 `\\?\` 扩展长度前缀的路径(如 `\\?\E:\project\...\App.tsx`)。`explorer.exe /select,` **无法解析该前缀**,导致无法定位/选中文件。
2. **explorer 退出码不可靠**:`explorer.exe` 即便成功打开窗口也常返回退出码 1(微软长期已知行为)。原代码对所有平台共用 `status.success()` 判定,于是把这个非零退出码当成失败弹了错误。

## 改动

仅改 `open_in_system_file_manager` 的 Windows 分支(macOS / Linux 行为逐字保持不变):

- 传给 `explorer` 前剥离 verbatim 前缀:`\\?\C:\dir` → `C:\dir`,`\\?\UNC\server\share` → `\\server\share`(等价于 `dunce` 库的处理,顺带兼容网络盘 / WSL 的 UNC 路径)。
- Windows 下不再以 explorer 退出码判定成败——只要进程成功启动即视为成功;只有真正启动失败(找不到 explorer)才返回错误。macOS / Linux 仍保留退出码检查。

## 测试

- `pnpm tauri dev` 编译通过(零错误零警告),应用正常启动。
- Windows 10 下右键文件 → 在系统文件夹中打开:资源管理器正确高亮目标文件,不再弹出退出码 1 的错误。
