### PR TITLE
修复 macOS WKWebView 在手机/Pad 远程输入时终端只能收到第一个字符的问题

### DIFF
--- a/src/components/ShellTerminalPanel.tsx
+++ b/src/components/ShellTerminalPanel.tsx
@@ -21,7 +21,7 @@ import {
   refreshTerminalDisplay,
   unregisterActiveTerminal,
 } from "./terminalShared";
-import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import { attachLinuxIMEFix, attachMacWebKitShiftInputFix, patchMacWebKitInputEvent } from "./terminalInputFix";
 import { Plus, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { useI18n } from "../i18n";
 import "@xterm/xterm/css/xterm.css";
@@ -143,6 +143,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
       const disposeCharSizeOverride = applyDomCharSizeOverride(term);
       const disposeScrollbarAutoHide = attachTerminalScrollbarAutoHide(term, container);
       const disposeInputFix = attachMacWebKitShiftInputFix(term);
+      const disposeRemoteInputPatch = patchMacWebKitInputEvent(term);
       const webglHandle = loadWebglAddon(term);
       const writer = createSmartWriter(term);
       const disposeMacWebKitGuard = attachMacWebKitTerminalGuard({ term, container, writer });
@@ -250,6 +251,7 @@ const ShellTerminalInstance = forwardRef<ShellTerminalInstanceHandle, {
         disposeScrollbarAutoHide();
         disposeMacWebKitGuard();
         disposeInputFix();
+        disposeRemoteInputPatch();
         term.dispose();
         invoke("kill_shell", { shellId }).catch(() => {});
       };

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -26,7 +26,7 @@ import {
   refreshTerminalDisplay,
   unregisterActiveTerminal,
 } from "./terminalShared";
-import { attachLinuxIMEFix, attachMacWebKitShiftInputFix } from "./terminalInputFix";
+import { attachLinuxIMEFix, attachMacWebKitShiftInputFix, patchMacWebKitInputEvent } from "./terminalInputFix";
 import "@xterm/xterm/css/xterm.css";
 
 interface TerminalViewProps {
@@ -173,7 +173,8 @@ export function TerminalView({
       onNewline: () => onInputRef.current(TERMINAL_NEWLINE_SEQUENCE),
     });
     const linuxIME = attachLinuxIMEFix(term, (data) => onInputRef.current(data));
-    const disposeOnData = { dispose: () => linuxIME.dispose() };
+    const disposeRemoteInputPatch = patchMacWebKitInputEvent(term);
+    const disposeOnData = { dispose: () => { disposeRemoteInputPatch(); linuxIME.dispose(); } };
 
     const handlePointerDown = (e: PointerEvent) => {
       if (e.button === 0) {

--- a/src/components/terminalInputFix.ts
+++ b/src/components/terminalInputFix.ts
@@ -1,6 +1,5 @@
 import type { Terminal } from "@xterm/xterm";
 import { IS_MAC_WEBKIT, IS_OTHER_WEBKIT } from "../platform";
-import type { XTermWithPrivates } from "./xterm-private";
 
 type TerminalWithInput = Pick<Terminal, "input" | "textarea">;
 
@@ -205,7 +204,10 @@ const NON_PRINTABLE_KEYS = new Set([
 
 function isMultiCharRemoteInput(key: string): boolean {
   return (
-    key.length > 1 && !NON_PRINTABLE_KEYS.has(key) && /^[\p{L}\p{N}\p{P}\p{S}\p{Zs}]+$/u.test(key)
+    key.length > 1 &&
+    !NON_PRINTABLE_KEYS.has(key) &&
+    // 远程输入法可能一次性发送带换行/制表符的多行文本（如粘贴），一并放行。
+    /^[\p{L}\p{N}\p{P}\p{S}\p{Zs}\r\n\t]+$/u.test(key)
   );
 }
 
@@ -213,16 +215,16 @@ function isMultiCharRemoteInput(key: string): boolean {
  * 修复 macOS WKWebView 在手机 / Pad 远程输入法（如 UU 远程）下，终端只能收到
  * 第一个字符的问题。
  *
- * 远程输入法会直接把候选词作为 KeyboardEvent.key 发送（例如 key="测试"），而
- * xterm 的 keypress 处理只会按 keyCode 发第一个字。这里在 capture 阶段拦截这
- * 种多字符 keypress，直接发送完整 key 文本。
+ * 远程输入法会把整段文本作为 KeyboardEvent.key 发送（例如 key="测试"、
+ * key="Hello\nWorld"），而 xterm 的 keypress 处理只会按 keyCode 发第一个字。
+ * 这里在 capture 阶段拦截这种多字符 keypress，通过公共 API `Terminal.input()`
+ * 发送完整 key 文本，避免依赖 `_core.coreService.triggerDataEvent` 私有入口。
  */
 export function patchMacWebKitInputEvent(term: Terminal): () => void {
   if (!IS_MAC_WEBKIT) {
     return () => {};
   }
 
-  const core = (term as XTermWithPrivates)._core;
   const element = term.element;
   const textarea = term.textarea;
   if (!element || !textarea) {
@@ -233,7 +235,7 @@ export function patchMacWebKitInputEvent(term: Terminal): () => void {
     if (event.target !== textarea) return;
     if (!isMultiCharRemoteInput(event.key)) return;
 
-    core.coreService.triggerDataEvent(event.key, true);
+    term.input(event.key, true);
     event.preventDefault();
     event.stopImmediatePropagation();
   };

--- a/src/components/terminalInputFix.ts
+++ b/src/components/terminalInputFix.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from "@xterm/xterm";
 import { IS_MAC_WEBKIT, IS_OTHER_WEBKIT } from "../platform";
+import type { XTermWithPrivates } from "./xterm-private";
 
 type TerminalWithInput = Pick<Terminal, "input" | "textarea">;
 
@@ -141,5 +142,105 @@ export function attachLinuxIMEFix(
       textarea.removeEventListener("keydown", handleKeyDownCapture, true);
       disposable.dispose();
     },
+  };
+}
+
+// 远程输入法（如 UU 远程）会把整段文本作为 KeyboardEvent.key 发送，例如
+// key="测试"、key="Hello, hello, hello."。这些不是普通功能键，需要走 keypress
+// 分支直接发完整文本；下面列出的标准功能键/控制键则必须排除。
+const NON_PRINTABLE_KEYS = new Set([
+  "Alt",
+  "AltGraph",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "Backspace",
+  "CapsLock",
+  "Clear",
+  "ContextMenu",
+  "Control",
+  "Dead",
+  "Delete",
+  "End",
+  "Enter",
+  "Escape",
+  "F1",
+  "F2",
+  "F3",
+  "F4",
+  "F5",
+  "F6",
+  "F7",
+  "F8",
+  "F9",
+  "F10",
+  "F11",
+  "F12",
+  "F13",
+  "F14",
+  "F15",
+  "F16",
+  "F17",
+  "F18",
+  "F19",
+  "F20",
+  "F21",
+  "F22",
+  "F23",
+  "F24",
+  "Home",
+  "Insert",
+  "Meta",
+  "NumLock",
+  "PageDown",
+  "PageUp",
+  "Pause",
+  "Process",
+  "ScrollLock",
+  "Shift",
+  "Tab",
+  "Unidentified",
+]);
+
+function isMultiCharRemoteInput(key: string): boolean {
+  return (
+    key.length > 1 && !NON_PRINTABLE_KEYS.has(key) && /^[\p{L}\p{N}\p{P}\p{S}\p{Zs}]+$/u.test(key)
+  );
+}
+
+/**
+ * 修复 macOS WKWebView 在手机 / Pad 远程输入法（如 UU 远程）下，终端只能收到
+ * 第一个字符的问题。
+ *
+ * 远程输入法会直接把候选词作为 KeyboardEvent.key 发送（例如 key="测试"），而
+ * xterm 的 keypress 处理只会按 keyCode 发第一个字。这里在 capture 阶段拦截这
+ * 种多字符 keypress，直接发送完整 key 文本。
+ */
+export function patchMacWebKitInputEvent(term: Terminal): () => void {
+  if (!IS_MAC_WEBKIT) {
+    return () => {};
+  }
+
+  const core = (term as XTermWithPrivates)._core;
+  const element = term.element;
+  const textarea = term.textarea;
+  if (!element || !textarea) {
+    return () => {};
+  }
+
+  const handleKeyPressCapture = (event: KeyboardEvent) => {
+    if (event.target !== textarea) return;
+    if (!isMultiCharRemoteInput(event.key)) return;
+
+    core.coreService.triggerDataEvent(event.key, true);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  element.addEventListener("keypress", handleKeyPressCapture, true);
+
+  return () => {
+    element.removeEventListener("keypress", handleKeyPressCapture, true);
   };
 }

--- a/src/components/xterm-private.d.ts
+++ b/src/components/xterm-private.d.ts
@@ -33,8 +33,13 @@ export interface XTermCharSizeService {
   _measureStrategy: XTermMeasureStrategy;
 }
 
+export interface XTermCoreService {
+  triggerDataEvent(data: string, userInput?: boolean): void;
+}
+
 export interface XTermCore {
   _charSizeService?: XTermCharSizeService;
+  coreService: XTermCoreService;
 }
 
 /** 包含 `_core` 私有入口的 Terminal——命名带 "Private" 便于 grep 定位。 */


### PR DESCRIPTION
## 问题

通过网易 UU 远程等工具，使用手机或 Pad 输入法远程控制 Mac 上的 NeZha 终端时，输入一段中文（如 "测试"）后，终端只能收到第一个字符。

## 原因

远程输入法会直接把候选词作为 KeyboardEvent.key 发送（例如 key="测试"），而 xterm.js 的 keypress 处理只会按 keyCode 发第一个字，导致后续字符丢失。

## 修复

在 macOS WKWebView 环境下，于 keypress 事件的 capture 阶段拦截多字符远程输入，直接调用 xterm 私有 API `core.coreService.triggerDataEvent(event.key, true)` 发送完整文本，避免 xterm 只发第一个字符。

## 改动文件

- src/components/terminalInputFix.ts：新增 patchMacWebKitInputEvent
- src/components/xterm-private.d.ts：补充 XTermCoreService 类型
- src/components/TerminalView.tsx：初始化终端时调用 patch
- src/components/ShellTerminalPanel.tsx：初始化 Shell 终端时调用 patch

已在本地 Apple Silicon 构建验证通过。
