### PR TITLE
fix(terminal): vertically align xterm text glyphs

### DIFF
--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -10,7 +10,7 @@ import type { XTermRasterizedGlyph, XTermWithPrivates } from "./xterm-private";
 // xterm 6 的自绘滚动条宽度由 overviewRuler.width 复用控制；FitAddon 会用它
 // 计算可用列数，因此必须和 App.css 中的滚动条槽宽保持一致。
 const XTERM_SCROLLBAR_WIDTH = 12;
-const TERMINAL_VERTICAL_ALIGN_SHIFT_PX = 1;
+const TERMINAL_LINE_HEIGHT = 1.1;
 
 // ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -528,7 +528,7 @@ function applyTerminalVerticalAlignCompensation(term: Terminal): void {
   const atlas = renderService?._renderer?.value?._charAtlas;
   if (!atlas || atlas.__nezhaVerticalAlignPatched) return;
 
-  const deviceShift = Math.round(TERMINAL_VERTICAL_ALIGN_SHIFT_PX * window.devicePixelRatio);
+  const deviceShift = Math.round(getTerminalVerticalAlignShift(term) * window.devicePixelRatio);
   if (deviceShift <= 0) return;
 
   const shiftedGlyphCache = new WeakMap<XTermRasterizedGlyph, XTermRasterizedGlyph>();
@@ -556,6 +556,11 @@ function applyTerminalVerticalAlignCompensation(term: Terminal): void {
   renderService?.refreshRows?.(0, term.rows - 1);
 }
 
+function getTerminalVerticalAlignShift(term: Terminal): number {
+  const fontSize = typeof term.options.fontSize === "number" ? term.options.fontSize : 12;
+  return Math.max(1, Math.min(2, Math.round(fontSize / 12)));
+}
+
 function shouldShiftTerminalGlyph(code: number): boolean {
   // xterm customGlyphs already draws these cell-filling symbols at the right position.
   // Shift font-rendered text and Nerd Font icons; keep Powerline and box/block glyphs stable.
@@ -576,6 +581,7 @@ export function initTerminal(
     cursorBlink: true,
     fontFamily,
     fontSize,
+    lineHeight: TERMINAL_LINE_HEIGHT,
     theme: themeFor(variant),
     minimumContrastRatio: minimumContrastRatioFor(variant),
     allowProposedApi: true,

--- a/src/components/terminalShared.ts
+++ b/src/components/terminalShared.ts
@@ -5,11 +5,12 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { IS_MAC_WEBKIT } from "../platform";
 import type { ThemeVariant } from "../types";
 // xterm 私有字段访问的显式契约——见 xterm-private.d.ts 头部说明。
-import type { XTermWithPrivates } from "./xterm-private";
+import type { XTermRasterizedGlyph, XTermWithPrivates } from "./xterm-private";
 
 // xterm 6 的自绘滚动条宽度由 overviewRuler.width 复用控制；FitAddon 会用它
 // 计算可用列数，因此必须和 App.css 中的滚动条槽宽保持一致。
 const XTERM_SCROLLBAR_WIDTH = 12;
+const TERMINAL_VERTICAL_ALIGN_SHIFT_PX = 1;
 
 // ── Theme ────────────────────────────────────────────────────────────────────
 
@@ -515,9 +516,52 @@ function refreshCharSizeAfterFontReady(term: Terminal, fontFamily: string): void
     if (term.options.fontFamily !== fontFamily) return;
     term.options.fontFamily = `${fontFamily}, monospace`;
     term.options.fontFamily = fontFamily;
+    applyTerminalVerticalAlignCompensation(term);
   } catch {
     /* term 已 dispose 的正常 race */
   }
+}
+
+function applyTerminalVerticalAlignCompensation(term: Terminal): void {
+  const core = (term as XTermWithPrivates)._core;
+  const renderService = core?._renderService;
+  const atlas = renderService?._renderer?.value?._charAtlas;
+  if (!atlas || atlas.__nezhaVerticalAlignPatched) return;
+
+  const deviceShift = Math.round(TERMINAL_VERTICAL_ALIGN_SHIFT_PX * window.devicePixelRatio);
+  if (deviceShift <= 0) return;
+
+  const shiftedGlyphCache = new WeakMap<XTermRasterizedGlyph, XTermRasterizedGlyph>();
+  const shiftFontGlyph = (glyph: XTermRasterizedGlyph): XTermRasterizedGlyph => {
+    const cached = shiftedGlyphCache.get(glyph);
+    if (cached) return cached;
+    const shifted = {
+      ...glyph,
+      offset: { ...glyph.offset, y: glyph.offset.y - deviceShift },
+    };
+    shiftedGlyphCache.set(glyph, shifted);
+    return shifted;
+  };
+
+  const originalGetGlyph = atlas.getRasterizedGlyph.bind(atlas);
+  const originalGetCombinedGlyph = atlas.getRasterizedGlyphCombinedChar.bind(atlas);
+
+  atlas.getRasterizedGlyph = (code, bg, fg, ext, restrictToCellHeight, domContainer) => {
+    const glyph = originalGetGlyph(code, bg, fg, ext, restrictToCellHeight, domContainer);
+    return shouldShiftTerminalGlyph(code) ? shiftFontGlyph(glyph) : glyph;
+  };
+  atlas.getRasterizedGlyphCombinedChar = (chars, bg, fg, ext, restrictToCellHeight, domContainer) =>
+    shiftFontGlyph(originalGetCombinedGlyph(chars, bg, fg, ext, restrictToCellHeight, domContainer));
+  atlas.__nezhaVerticalAlignPatched = true;
+  renderService?.refreshRows?.(0, term.rows - 1);
+}
+
+function shouldShiftTerminalGlyph(code: number): boolean {
+  // xterm customGlyphs already draws these cell-filling symbols at the right position.
+  // Shift font-rendered text and Nerd Font icons; keep Powerline and box/block glyphs stable.
+  if (code >= 0xe0a4 && code <= 0xe0d6) return false;
+  if (code >= 0x2500 && code <= 0x259f) return false;
+  return true;
 }
 
 export function initTerminal(
@@ -760,6 +804,7 @@ export function loadWebglAddon(term: Terminal): WebglAddonHandle {
         addon = null;
       });
       term.loadAddon(addon);
+      applyTerminalVerticalAlignCompensation(term);
       scheduleTextureAtlasRefresh(term);
       void whenFontEventuallyReady(fontFamily, fontSize).then(() => {
         if (!disposed && term.element) {
@@ -812,6 +857,7 @@ export function safeFit(
     if (!dims || !Number.isFinite(dims.cols) || !Number.isFinite(dims.rows)) return null;
     if (dims.cols < 2 || dims.rows < 2) return null;
     fitAddon.fit();
+    applyTerminalVerticalAlignCompensation(term);
     return { cols: term.cols, rows: term.rows };
   } catch {
     return null;
@@ -830,6 +876,7 @@ export function applyTerminalFontSize(
   if (term.options.fontSize === fontSize) return null;
   term.options.fontSize = fontSize;
   const result = safeFit(fitAddon, term, container);
+  applyTerminalVerticalAlignCompensation(term);
   scheduleTextureAtlasRefresh(term);
   return result;
 }
@@ -851,10 +898,13 @@ export function applyTerminalFontFamily(
   term.options.fontFamily = fontFamily;
   const fontSize = typeof term.options.fontSize === "number" ? term.options.fontSize : 12;
   const immediate = safeFit(fitAddon, term, container);
+  applyTerminalVerticalAlignCompensation(term);
   const whenSettled = waitForFontReady(fontFamily, fontSize).then(() => {
     refreshCharSizeAfterFontReady(term, fontFamily);
     scheduleTextureAtlasRefresh(term);
-    return safeFit(fitAddon, term, container);
+    const settled = safeFit(fitAddon, term, container);
+    applyTerminalVerticalAlignCompensation(term);
+    return settled;
   });
   return { immediate, whenSettled };
 }

--- a/src/components/xterm-private.d.ts
+++ b/src/components/xterm-private.d.ts
@@ -9,6 +9,8 @@
  * 升级 xterm 时检查（源参考 `node_modules/@xterm/xterm/src/browser/services/CharSizeService.ts`）：
  *   - `Terminal._core._charSizeService._measureStrategy.measure()` 是否仍存在
  *   - `IMeasureResult` 字段是否仍是 `{ width, height }`
+ *   - `Terminal._core._renderService._renderer.value._charAtlas` 是否仍存在
+ *   - `ITextureAtlas.getRasterizedGlyph*()` 和 `IRasterizedGlyph.offset` 是否仍兼容
  *
  * 字段名在 minified bundle 中未被 mangle（DI service token + class field），
  * 但 xterm 团队不承诺稳定。
@@ -35,6 +37,43 @@ export interface XTermCharSizeService {
 
 export interface XTermCore {
   _charSizeService?: XTermCharSizeService;
+  _renderService?: {
+    refreshRows?(start: number, end: number): void;
+    _renderer?: {
+      value?: {
+        _charAtlas?: XTermTextureAtlas;
+      };
+    };
+  };
+}
+
+export interface XTermRasterizedGlyph {
+  offset: { x: number; y: number };
+  texturePage: number;
+  texturePosition: { x: number; y: number };
+  texturePositionClipSpace: { x: number; y: number };
+  size: { x: number; y: number };
+  sizeClipSpace: { x: number; y: number };
+}
+
+export interface XTermTextureAtlas {
+  getRasterizedGlyph(
+    code: number,
+    bg: number,
+    fg: number,
+    ext: number,
+    restrictToCellHeight: boolean,
+    domContainer: HTMLElement | undefined,
+  ): XTermRasterizedGlyph;
+  getRasterizedGlyphCombinedChar(
+    chars: string,
+    bg: number,
+    fg: number,
+    ext: number,
+    restrictToCellHeight: boolean,
+    domContainer: HTMLElement | undefined,
+  ): XTermRasterizedGlyph;
+  __nezhaVerticalAlignPatched?: boolean;
 }
 
 /** 包含 `_core` 私有入口的 Terminal——命名带 "Private" 便于 grep 定位。 */


### PR DESCRIPTION
## Why

xterm text glyphs in both the agent terminal and embedded shell terminal rendered slightly above the vertical center of the terminal cell. Powerline separators such as `` / `` were already correctly aligned, while normal text and Nerd Font icons needed a small baseline compensation.

## What changed

This adds a shared xterm WebGL glyph alignment compensation in `terminalShared.ts`:

- shifts font-rendered text glyphs down by one CSS pixel in device pixels
- keeps Powerline and box/block drawing glyphs untouched so separators remain aligned
- caches shifted glyph wrappers with `WeakMap` to avoid allocations in the render hot path
- records the added xterm private WebGL atlas contract in `xterm-private.d.ts`

## Validation

- `pnpm lint`
- `pnpm test -- src/test/terminal-theme.test.ts`
- `pnpm build`

## Screenshots

Draft PR. Terminal before/after screenshots should be attached before marking ready for review.
