### PR TITLE
fix(storage): prevent task data loss after sudden system reboot

### DIFF
--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -120,28 +121,44 @@ pub fn load_project_tasks(project_id: String) -> Result<Vec<Task>, String> {
         return Ok(vec![]);
     }
     let raw = fs::read_to_string(&path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&raw).map_err(|e| e.to_string())
+    serde_json::from_str(&raw).map_err(|parse_err| {
+        // 系统崩溃(掉电/蓝屏)可能留下空或截断的 tasks.json。把损坏文件挪走
+        // 保留人工恢复现场,下次启动即回到正常空列表,不会永久卡死在解析报错上。
+        let secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let backup = path.with_file_name(format!("tasks.json.corrupt-{secs}"));
+        match fs::rename(&path, &backup) {
+            Ok(()) => format!(
+                "tasks.json is corrupted ({parse_err}); moved to {} for manual recovery",
+                backup.display()
+            ),
+            Err(mv_err) => {
+                format!("tasks.json is corrupted ({parse_err}); failed to move it aside: {mv_err}")
+            }
+        }
+    })
 }
 
 #[tauri::command]
 pub fn save_project_tasks(project_id: String, tasks: Vec<Task>) -> Result<(), String> {
     ensure_project_dir(&project_id)?;
-    let path = tasks_path(&project_id)?;
-    if tasks.is_empty() {
-        // Remove the file if no tasks left
-        if path.exists() {
-            fs::remove_file(&path).map_err(|e| e.to_string())?;
-        }
-        return Ok(());
-    }
+    // 空列表也照常写 "[]",不删文件:删除路径曾放大过崩溃后的数据丢失
+    // (加载失败 → 前端空 state → 空列表保存把磁盘上仅存的原始文件删掉)。
     let raw = serde_json::to_string_pretty(&tasks).map_err(|e| e.to_string())?;
-    atomic_write(&path, &raw)
+    atomic_write(&tasks_path(&project_id)?, &raw)
 }
 
 // ── Atomic write (write to tmp then rename) ───────────────────────────────────
 
-/// 原子写入：先写入唯一临时文件，再 rename 到目标路径。
+/// 原子写入：先写入唯一临时文件，fsync 落盘后再 rename 到目标路径。
 /// 临时文件名包含 pid + 纳秒时间戳，避免并发写入时临时文件相互覆盖。
+///
+/// rename 只保证元数据原子性,不保证数据先于 rename 落盘——NTFS/APFS 都只
+/// journal 元数据,掉电/系统崩溃时会留下 0 字节或截断的目标文件(Windows 用户
+/// 实际踩过:突然重启后 tasks.json 清空)。rename 前必须 sync_all
+/// (Windows=FlushFileBuffers,macOS=F_FULLFSYNC)强制数据先持久化。
 pub fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
     let uid = format!(
         "{}-{}",
@@ -153,6 +170,17 @@ pub fn atomic_write(path: &Path, content: &str) -> Result<(), String> {
     );
     let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
     let tmp = path.with_file_name(format!(".{file_name}.{uid}.tmp"));
-    fs::write(&tmp, content).map_err(|e| e.to_string())?;
-    fs::rename(&tmp, path).map_err(|e| e.to_string())
+    let write_and_sync = || -> std::io::Result<()> {
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()
+    };
+    if let Err(e) = write_and_sync() {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.to_string());
+    }
+    fs::rename(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        e.to_string()
+    })
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,12 +78,26 @@ function persistProjects(
   });
 }
 
+// 启动时任务加载失败(文件损坏/IO 错误)的项目。本次会话内禁止对这些项目
+// 覆盖写盘——此时内存 state 是空的,一旦写出去会把磁盘上尚可人工恢复的
+// 数据覆盖或清空。重启后重新加载成功即自动解除。
+const taskPersistBlockedProjectIds = new Set<string>();
+
 function persistProjectTasks(
   projectId: string,
   allTasks: Task[],
   onError: (msg: string) => void,
   formatError: (error: string, projectId: string) => string,
 ) {
+  if (taskPersistBlockedProjectIds.has(projectId)) {
+    onError(
+      formatError(
+        "tasks failed to load at startup; saving is disabled to protect on-disk data (restart to retry)",
+        projectId,
+      ),
+    );
+    return;
+  }
   invoke("save_project_tasks", {
     projectId,
     tasks: allTasks.filter((t) => t.projectId === projectId),
@@ -94,6 +108,7 @@ function persistProjectTasks(
 }
 
 function persistProjectTasksQuietly(projectId: string, allTasks: Task[]) {
+  if (taskPersistBlockedProjectIds.has(projectId)) return;
   invoke("save_project_tasks", {
     projectId,
     tasks: allTasks.filter((t) => t.projectId === projectId),
@@ -519,10 +534,25 @@ function App() {
       }
       setProjects(projectsForState);
 
-      // Load tasks for all known projects
-      const chunks = await Promise.all(
+      // Load tasks for all known projects。allSettled 隔离单项目失败:
+      // 一个 tasks.json 损坏不能让所有项目的任务在 UI 里消失(Promise.all
+      // 整体 reject 曾造成这个假象),失败项目单独提示并禁止写盘。
+      const results = await Promise.allSettled(
         loadedProjects.map((p) => invoke<Task[]>("load_project_tasks", { projectId: p.id })),
       );
+      const chunks: Task[][] = [];
+      results.forEach((result, i) => {
+        if (result.status === "fulfilled") {
+          chunks.push(result.value);
+          return;
+        }
+        const project = loadedProjects[i];
+        taskPersistBlockedProjectIds.add(project.id);
+        console.error(result.reason);
+        showToast(
+          t("toast.loadTasksFailed", { name: project.name, error: String(result.reason) }),
+        );
+      });
       const activeTaskIds = new Set(await invoke<string[]>("get_active_task_ids"));
       const { tasks: loadedTasks, changedProjectIds } = normalizeInterruptedTasksOnStartup(
         chunks.flat(),

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -542,6 +542,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
       "Failed to load project file list, @ references unavailable: {error}",
     "toast.saveProjectsFailed": "Failed to save project list: {error}",
     "toast.saveTasksFailed": "Failed to save tasks for project {projectId}: {error}",
+    "toast.loadTasksFailed":
+      "Failed to load tasks for project {name}: {error}. Saving for this project is disabled until restart to protect on-disk data.",
   },
   zh: {
     "appSettings.title": "应用设置",
@@ -1054,6 +1056,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "toast.loadProjectFilesFailed": "加载项目文件列表失败，@ 引用不可用：{error}",
     "toast.saveProjectsFailed": "保存项目列表失败：{error}",
     "toast.saveTasksFailed": "保存任务失败（项目 {projectId}）：{error}",
+    "toast.loadTasksFailed":
+      "加载任务失败（项目 {name}）：{error}。为保护磁盘数据，重启前将不再保存该项目的任务。",
   },
 };
 


### PR DESCRIPTION
A Windows user lost all tasks after a power-loss reboot while projects survived. Three compounding causes:

1. atomic_write renamed the tmp file without fsync. NTFS/APFS only journal metadata, so a crash could leave a zero-length/truncated tasks.json (tasks.json is written on every status change, hence far more exposed than projects.json).
2. Frontend init() loaded all projects' tasks via Promise.all, so one corrupted file rejected the whole batch silently and every project's tasks vanished from the UI.
3. Any subsequent task operation overwrote surviving files from the empty in-memory state, and save_project_tasks deleted the file outright when the list was empty.

Fixes: sync_all before rename (FlushFileBuffers / F_FULLFSYNC); move a corrupted tasks.json aside as tasks.json.corrupt-<ts> for manual recovery instead of failing forever; isolate per-project load failures with Promise.allSettled, toast the error, and block persisting for failed projects until restart; always write "[]" instead of deleting the file.