### PR TITLE
fix(file-explorer): serialize watch ops and notify overlapping dirs

### DIFF
--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -55,12 +55,17 @@ pub fn init(app: &tauri::App) {
             let watched = handler_watched.lock();
             for path in &event.paths {
                 // 非递归 watch 的事件路径要么是被监听目录的直接子项,要么是目录自身。
+                let mut dirty = HashSet::new();
                 if watched.contains_key(path.as_path()) {
-                    let _ = tx.send(path.clone());
-                } else if let Some(parent) = path.parent() {
+                    dirty.insert(path.clone());
+                }
+                if let Some(parent) = path.parent() {
                     if watched.contains_key(parent) {
-                        let _ = tx.send(parent.to_path_buf());
+                        dirty.insert(parent.to_path_buf());
                     }
+                }
+                for dir in dirty {
+                    let _ = tx.send(dir);
                 }
             }
         },

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -174,6 +174,10 @@ export function FileExplorer({
   const refreshIdRef = useRef(0);
   // 已注册到后端 fs_watcher 的目录集合(项目根 + 可见的已展开目录)。
   const watchedRef = useRef<Set<string>>(new Set());
+  // 各目录在途的 watch_dir 调用。unwatch 必须排在它之后发出,保证后端引用计数
+  // 严格按「先 +1 后 -1」配对——否则 watch 未落地时 unwatch 先到会空扣,
+  // 随后落地的 watch 变成泄漏,或反过来把其他实例的计数打到 0。
+  const pendingWatchRef = useRef<Map<string, Promise<unknown>>>(new Map());
   // 后端 watcher 不可用(平台不支持等)时置 true,回退到固定间隔轮询。
   const [watcherFailed, setWatcherFailed] = useState(false);
 
@@ -261,30 +265,39 @@ export function FileExplorer({
   useEffect(() => {
     const targets = active ? collectWatchTargets(nodes, projectPath) : new Set<string>();
     const watched = watchedRef.current;
+    const pending = pendingWatchRef.current;
     for (const dir of targets) {
       if (watched.has(dir)) continue;
       watched.add(dir);
-      invoke<boolean>("watch_dir", { path: dir, projectPath })
+      const request = invoke<boolean>("watch_dir", { path: dir, projectPath })
         .then((ok) => {
-          if (!ok) setWatcherFailed(true);
+          if (!ok && watchedRef.current.has(dir)) setWatcherFailed(true);
         })
         .catch(() => {
-          watched.delete(dir);
+          // invoke 本身失败(路径校验等):摘除后待下一次树更新重试。
+          watchedRef.current.delete(dir);
+        })
+        .finally(() => {
+          if (pending.get(dir) === request) pending.delete(dir);
         });
+      pending.set(dir, request);
     }
     for (const dir of [...watched]) {
       if (targets.has(dir)) continue;
       watched.delete(dir);
-      invoke("unwatch_dir", { path: dir }).catch(() => {});
+      const inflight = pending.get(dir) ?? Promise.resolve();
+      void inflight.then(() => invoke("unwatch_dir", { path: dir })).catch(() => {});
     }
   }, [active, nodes, projectPath]);
 
   // 卸载时摘除全部 watch,避免后端残留引用计数。
   useEffect(() => {
     const watched = watchedRef.current;
+    const pending = pendingWatchRef.current;
     return () => {
       for (const dir of watched) {
-        invoke("unwatch_dir", { path: dir }).catch(() => {});
+        const inflight = pending.get(dir) ?? Promise.resolve();
+        void inflight.then(() => invoke("unwatch_dir", { path: dir })).catch(() => {});
       }
       watched.clear();
     };


### PR DESCRIPTION
- queue unwatch_dir behind the in-flight watch_dir per dir so backend refcounts always pair +1/-1 in order; out-of-order unwatch could leak a watch or drop another instance's refcount to zero
- notify callback: emit both the watched dir itself and its watched parent instead of else-if (deleting a watched dir must refresh both)