### PR TITLE
feat(window): minimize to system tray on close for Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tokio",
  "toml 0.8.2",
  "trash",
@@ -4564,6 +4565,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
@@ -43,6 +43,11 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 uuid = { version = "1", features = ["v4"] }
 trash = "=5.2.6"
 font-kit = "=0.14.3"
+
+# 仅 Windows:关闭到托盘后进程常驻,需单实例守卫防止再次打开图标时启动重复后端
+# (两套 watcher/hook 抢写同一批 ~/.nezha 文件)。
+[target.'cfg(windows)'.dependencies]
+tauri-plugin-single-instance = "2"
 
 [profile.dev]
 debug = 0

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,19 @@ impl TaskManager {
         writers.remove(id);
         children.remove(id);
     }
+
+    /// 退出前终止所有仍在运行的任务/Shell 子进程。
+    /// 托盘「退出」走 `app.exit(0)`(即 `std::process::exit`,不跑 Drop),
+    /// 没有这一步会把正在跑的 claude/codex 子进程留成孤儿,继续占用 CPU / API 额度。
+    /// 先 clone 出 Arc 再逐个 kill,避免持有 `child_handles` 锁期间做阻塞调用。
+    pub(crate) fn kill_all_children(&self) {
+        let children: Vec<_> = self.child_handles.lock().values().cloned().collect();
+        for arc in children {
+            if let Ok(mut child) = arc.lock() {
+                let _ = child.kill();
+            }
+        }
+    }
 }
 
 /// macOS: 把主窗口收起到 Dock(hide 而非退出)。
@@ -99,9 +112,141 @@ fn hide_main_window(window: tauri::Window) {
     let _ = window;
 }
 
+/// 把主窗口重新显示并聚焦(唤回)。
+/// 窗口可能同时处于 hidden + minimized,故先 unminimize 再 show + focus。
+/// Windows: 托盘左键 / 托盘菜单「显示」/ 单实例第二实例唤回都走这里。
+/// macOS: 点 Dock 图标(Reopen)唤回走这里。
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn show_main_window(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Windows 托盘菜单构建。文案由调用方提供,翻译唯一事实源保持在前端 src/i18n.tsx:
+/// 启动时用英文兜底(见 TRAY_FALLBACK_LABELS),webview 挂载后与语言切换时由
+/// update_tray_menu 命令传入当前语言文案整体重建。
+/// 菜单项 id("show"/"quit")固定不变,事件处理无需随语言调整。
+#[cfg(target_os = "windows")]
+fn build_tray_menu(
+    app: &tauri::AppHandle,
+    show_label: &str,
+    quit_label: &str,
+) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    use tauri::menu::{Menu, MenuItem};
+
+    let show_item = MenuItem::with_id(app, "show", show_label, true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "quit", quit_label, true, None::<&str>)?;
+    Menu::with_items(app, &[&show_item, &quit_item])
+}
+
+/// 托盘创建时的兜底文案(英文,与 i18n.tsx 词典缺失时回退 en 的约定一致)。
+/// 后端无法读取 webview localStorage 中的语言偏好,启动时只能兜底;
+/// I18nProvider 挂载后会立即通过 update_tray_menu 覆盖为实际语言,
+/// 兜底文案仅在 webview 加载完成前的短暂窗口(或前端加载失败时)可见。
+#[cfg(target_os = "windows")]
+const TRAY_FALLBACK_LABELS: (&str, &str) = ("Show Nezha", "Quit");
+
+/// 前端在语言初始化/切换时调用(见 src/i18n.tsx 的 language effect),
+/// 用当前语言文案重建 Windows 托盘菜单;其他平台为 no-op。
+/// 文案由前端 t() 词典生成后作为参数传入,Rust 侧不持有 zh/en 翻译。
+/// 原生菜单是线程亲和对象,统一切回主线程重建,不在命令线程直接操作。
+#[tauri::command]
+fn update_tray_menu(app: tauri::AppHandle, show_label: String, quit_label: String) {
+    #[cfg(target_os = "windows")]
+    {
+        let handle = app.clone();
+        let dispatched = app.run_on_main_thread(move || {
+            let Some(tray) = handle.tray_by_id("main") else {
+                // setup_tray 构建失败时托盘不存在(setup 阶段会直接报错),此处无可更新对象。
+                return;
+            };
+            let applied = build_tray_menu(&handle, &show_label, &quit_label)
+                .and_then(|menu| tray.set_menu(Some(menu)));
+            if let Err(_e) = applied {
+                #[cfg(debug_assertions)]
+                eprintln!("[tray] 更新托盘菜单失败: {_e}");
+            }
+        });
+        if let Err(_e) = dispatched {
+            #[cfg(debug_assertions)]
+            eprintln!("[tray] 无法调度到主线程更新托盘菜单: {_e}");
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = (app, show_label, quit_label);
+}
+
+/// Windows: 创建系统托盘图标。
+/// 左键点击托盘图标唤回窗口;右键菜单提供「显示/退出」。
+/// 关闭按钮(X)只隐藏窗口(见 on_window_event),真正退出走托盘菜单的「退出」。
+#[cfg(target_os = "windows")]
+fn setup_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
+    use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+    use tauri::Manager;
+
+    let menu = build_tray_menu(app, TRAY_FALLBACK_LABELS.0, TRAY_FALLBACK_LABELS.1)?;
+
+    let mut builder = TrayIconBuilder::with_id("main")
+        .tooltip("Nezha")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "show" => show_main_window(app),
+            "quit" => {
+                // 关闭按钮只隐藏窗口,「退出」是关到托盘后的主要退出路径。
+                // app.exit(0) 走 std::process::exit 不跑 Drop,先显式杀掉任务子进程,
+                // 否则正在跑的 claude/codex 会变孤儿。
+                app.state::<TaskManager>().kill_all_children();
+                app.exit(0);
+            }
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    } else {
+        // icon 缺失时托盘无图标 → 窗口 hide 后通知区几乎不可见、难以找回。
+        // 正常 bundle 里 default_window_icon() 恒为 Some(见 tauri.conf.json icons),
+        // 这里只在异常配置/加载失败时留一条 dev 日志,避免变成静默黑箱。
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "[tray] default_window_icon() 返回 None:托盘将无图标,关到托盘后窗口可能难以找回"
+        );
+    }
+
+    builder.build(app)?;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // Windows: 单实例守卫必须作为第一个插件注册。关闭到托盘后进程仍常驻,用户从开始
+    // 菜单/桌面图标再次打开会启动第二个完整后端实例——两套 fs_watcher/event_watcher/
+    // hook watcher 对同一批 ~/.nezha 文件并发运行,导致通知重复、tasks.json 被
+    // last-writer-wins 写坏。第二个实例通过此回调把已有窗口唤回并聚焦后自动退出。
+    // macOS 由 LaunchServices 天然单实例,无需此守卫。
+    #[cfg(target_os = "windows")]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        show_main_window(app);
+    }));
+
+    builder
         .setup(|app| {
             // 后台预热 login shell 环境，避免第一次启动任务时阻塞
             std::thread::spawn(|| {
@@ -120,6 +265,9 @@ pub fn run() {
             crate::event_watcher::start(app.handle().clone());
             // 文件树的 fs 事件监听(watch_dir/unwatch_dir 的托管状态与防抖线程)
             crate::fs_watcher::init(app);
+            // Windows: 创建系统托盘图标(关闭窗口时收起到托盘,而非退出)
+            #[cfg(target_os = "windows")]
+            setup_tray(app.handle())?;
             Ok(())
         })
         .manage(TaskManager {
@@ -142,13 +290,22 @@ pub fn run() {
                 hide_window_to_dock(window.clone());
                 api.prevent_close();
             }
-            #[cfg(not(target_os = "macos"))]
+            // Windows: 点关闭按钮(X)时隐藏窗口到托盘而非退出;
+            // 从托盘图标左键点击或右键菜单「显示 Nezha」唤回,「退出」才真正结束进程。
+            #[cfg(target_os = "windows")]
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let _ = window.hide();
+                api.prevent_close();
+            }
+            // 其他平台(Linux)没有托盘唤回入口,保持默认退出行为,避免窗口隐藏后无法找回。
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
             let _ = (window, event);
         })
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             hide_main_window,
+            update_tray_menu,
             pty::run_task,
             pty::resume_task,
             pty::cancel_task,
@@ -246,15 +403,10 @@ pub fn run() {
         .run(|_app_handle, _event| {
             // macOS: 当窗口被 Cmd+W 隐藏（hide）后，点击 Dock 图标会触发 Reopen，
             // 此时没有可见窗口，需要手动把主窗口重新显示并聚焦。
+            // 复用 show_main_window(与托盘唤回同一实现),避免两处唤回逻辑分叉。
             #[cfg(target_os = "macos")]
-            {
-                use tauri::Manager;
-                if let tauri::RunEvent::Reopen { .. } = _event {
-                    if let Some(window) = _app_handle.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
-                }
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                show_main_window(_app_handle);
             }
         });
 }

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 
 export type AppLanguage = "en" | "zh";
 
@@ -515,6 +516,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "notification.loadingFailed": "Failed to load notifications",
     "notification.unread": "unread",
     "notification.noNotifications": "No notifications",
+    "tray.showApp": "Show Nezha",
+    "tray.quit": "Quit",
     "toolbar.fileExplorer": "File Explorer",
     "toolbar.gitChanges": "Git Changes",
     "toolbar.gitHistory": "Git History",
@@ -1030,6 +1033,8 @@ const translations: Record<AppLanguage, Record<string, string>> = {
     "notification.loadingFailed": "加载通知失败",
     "notification.unread": "未读",
     "notification.noNotifications": "暂无通知",
+    "tray.showApp": "显示 Nezha",
+    "tray.quit": "退出",
     "toolbar.fileExplorer": "文件浏览器",
     "toolbar.gitChanges": "Git 变更",
     "toolbar.gitHistory": "Git 历史",
@@ -1092,6 +1097,15 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
     document.documentElement.lang = language === "zh" ? "zh-CN" : "en";
+    // 同步当前语言的托盘菜单文案(Windows)。文案在前端词典生成,保持 i18n.tsx
+    // 是唯一翻译源;Rust 侧只应用文案,不持有 zh/en 字典。
+    // 非 Tauri 环境(单测 jsdom)没有 IPC 桥,直接跳过。
+    if ("__TAURI_INTERNALS__" in window) {
+      invoke("update_tray_menu", {
+        showLabel: translations[language]["tray.showApp"],
+        quitLabel: translations[language]["tray.quit"],
+      }).catch((err) => console.warn("[i18n] update_tray_menu failed:", err));
+    }
   }, [language]);
 
   const t = useCallback(


### PR DESCRIPTION
Closes #264

> **本 PR 替代已关闭的 #362**:应维护者要求,已将 #362 的功能提交与后续 review 修复 rebase 到最新 main 并压缩为**单个提交**(`0e64b13`),内容与 #362+修复的最终状态逐字节一致(tree hash 验证)。CI 阻塞项(RUSTSEC-2026-0204)已随 main 的 `f32f84e` 修复,本 PR 基于其后的 main。

## Why

Windows 上点关闭按钮(X)会直接退出应用,而不少用户希望像常驻类工具一样「关闭到右下角托盘」——窗口收起、后台继续跑,需要时再从托盘唤回,避免误关正在运行的 agent 任务(#264 的诉求)。macOS 已有「关闭 → 隐藏到 Dock + 点 Dock 图标唤回」,本 PR 在 Windows 上补齐对等能力,复用同一套唤回逻辑,不改动 macOS / Linux 现状。

## What(取舍说明)

- **仅 Windows 生效**:改动全部 `#[cfg(target_os = "windows")]` 门控。Linux 没有托盘/Dock 唤回入口,保持默认退出。
- **无条件关闭到托盘**(不加设置开关):与既有 macOS「关闭即隐藏」一致;真正退出由托盘右键菜单「退出」提供。
- **单实例守卫**(`tauri-plugin-single-instance`,Windows-only):关到托盘后进程常驻,再次打开图标会启动第二个后端实例——两套 watcher 并发抢写 `~/.nezha` 会导致通知重复、tasks.json 写坏。第二实例改为唤回已有窗口后自动退出。
- **退出时清理子进程**:托盘「退出」走 `app.exit(0)`(不跑 Drop),显式 `kill_all_children()` 防止 claude/codex 孤儿进程。
- **托盘菜单文案跟随应用语言**(回应 #362 的 review 意见):翻译唯一事实源在前端 `src/i18n.tsx`(新增 `tray.showApp` / `tray.quit` 中英词条),语言初始化/切换时经 `update_tray_menu` 命令传给后端,在主线程整体重建菜单;Rust 侧不持有 zh/en 字典。托盘创建瞬间用英文兜底(后端读不到 webview localStorage),webview 挂载后立即覆盖;若倾向默认中文,改一行 `TRAY_FALLBACK_LABELS` 即可。
- **唤回逻辑统一**:托盘左键、菜单「显示」、单实例唤回、macOS Reopen 全部复用 `show_main_window()`。

## Scope

- `src-tauri/`:`Cargo.toml`(`tray-icon` feature + Windows-only 单实例插件)、`Cargo.lock`、`src/lib.rs`。
- `src/i18n.tsx`:新增 tray 词条(中英)+ language effect 同步文案到后端(非 Tauri 环境跳过,不影响单测)。

## 验证

- Windows 本地 `pnpm tauri dev`:托盘创建正常;点 X 收起、左键/菜单唤回、「退出」真正结束进程;中英切换后右键菜单文案即时跟随。

> 合并方式建议 Rebase and merge(保留原作者署名)。