### PR TITLE
feat(file-explorer): use Material Icon Theme for file tree icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Nezha 的诞生离不开以下优秀的开源项目，向它们致敬：
 - [Tauri](https://github.com/tauri-apps/tauri) - 构建更小、更快、更安全的桌面应用
 - [React](https://github.com/facebook/react) - 构建用户界面的 JavaScript 库
 - [xterm.js](https://github.com/xtermjs/xterm.js) - 强大的 Web 终端组件
+- [Material Icon Theme](https://github.com/material-extensions/vscode-material-icon-theme) - 文件浏览器使用的文件与文件夹图标
 
 感谢以下自媒体对本项目的关注和转发(以下排名不分先后), 大家感兴趣的话可以关注下他们 ～
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dompurify": "^3.3.3",
     "lucide-react": "^1.7.0",
     "marked": "^17.0.5",
+    "material-icon-theme": "5.38.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shiki": "^4.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       marked:
         specifier: ^17.0.5
         version: 17.0.5
+      material-icon-theme:
+        specifier: 5.38.1
+        version: 5.38.1
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1714,6 +1717,9 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  chroma-js@3.2.0:
+    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
+
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
@@ -2366,6 +2372,10 @@ packages:
     resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  material-icon-theme@5.38.1:
+    resolution: {integrity: sha512-14cFM4NJGdbuo68rIZTq9TSX0f5BtA6VF+eNX3zq23Z5NoEeVtM4Zn4PpZ0ERl++50jCBrywKFWXmOjbxf0xTA==}
+    engines: {vscode: ^1.55.0}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4604,6 +4614,8 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
+  chroma-js@3.2.0: {}
+
   codemirror@6.0.2:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -5390,6 +5402,10 @@ snapshots:
       semver: 7.7.4
 
   marked@17.0.5: {}
+
+  material-icon-theme@5.38.1:
+    dependencies:
+      chroma-js: 3.2.0
 
   math-intrinsics@1.1.0: {}
 

--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,7 @@
 @import "./styles/font-selector.css";
 @import "./styles/git-history.css";
 @import "./styles/layout.css";
+@import "./styles/file-explorer.css";
 @import "./styles/app-settings.css";
 
 /* ── Reset ─────────────────────────────────────────────────────── */

--- a/src/components/file-explorer/FileIcon.tsx
+++ b/src/components/file-explorer/FileIcon.tsx
@@ -1,7 +1,11 @@
-import s from "../../styles";
-import { getFileColor } from "../../utils";
-import { GITIGNORED_COLOR } from "./types";
+import { useIsLightTheme } from "../../hooks/useIsLightTheme";
+import { getFileIconUrl, getFolderIconUrl } from "./materialIcons";
 
+/**
+ * File / folder icon for explorer rows, search results, drag previews and the
+ * create-input row. Renders a Material Icon Theme SVG as a plain <img>;
+ * gitignored entries are greyed out purely in CSS (`data-ignored`).
+ */
 export function FileIcon({
   name,
   ext,
@@ -15,26 +19,18 @@ export function FileIcon({
   expanded?: boolean;
   isGitignored?: boolean;
 }) {
-  if (isDir) {
-    const folderColor = isGitignored
-      ? GITIGNORED_COLOR
-      : expanded
-        ? "var(--icon-folder-open)"
-        : "var(--icon-folder)";
-    return (
-      <span style={{ ...s.fileIconFolder, color: folderColor }}>
-        {expanded ? (
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M1 3.5A1.5 1.5 0 012.5 2h3.764c.58 0 1.12.34 1.342.87l.496 1.13H13.5A1.5 1.5 0 0115 5.5v7A1.5 1.5 0 0113.5 14h-11A1.5 1.5 0 011 12.5v-9z" />
-          </svg>
-        ) : (
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M1 3.5A1.5 1.5 0 012.5 2h3.764c.58 0 1.12.34 1.342.87l.496 1.13H13.5A1.5 1.5 0 0115 5.5v7A1.5 1.5 0 0113.5 14h-11A1.5 1.5 0 011 12.5v-9zM2.5 3a.5.5 0 00-.5.5v9a.5.5 0 00.5.5h11a.5.5 0 00.5-.5v-7a.5.5 0 00-.5-.5H8l-.724-1.647A.5.5 0 007.264 3H2.5z" />
-          </svg>
-        )}
-      </span>
-    );
-  }
-  const color = isGitignored ? GITIGNORED_COLOR : getFileColor(name, ext);
-  return <span style={{ ...s.fileIconFile, background: color }} />;
+  const isLight = useIsLightTheme();
+  const src = isDir
+    ? getFolderIconUrl(name, Boolean(expanded), isLight)
+    : getFileIconUrl(name, ext, isLight);
+  return (
+    <img
+      className="file-icon"
+      src={src}
+      alt=""
+      draggable={false}
+      data-ignored={isGitignored || undefined}
+      aria-hidden="true"
+    />
+  );
 }

--- a/src/components/file-explorer/materialIconNames.ts
+++ b/src/components/file-explorer/materialIconNames.ts
@@ -1,0 +1,98 @@
+import {
+  file as DEFAULT_FILE_ICON,
+  fileExtensions,
+  fileNames,
+  folder as DEFAULT_FOLDER_ICON,
+  folderExpanded as DEFAULT_FOLDER_OPEN_ICON,
+  folderNames,
+  light,
+} from "material-icon-theme/dist/material-icons.json";
+
+/**
+ * Manifest half of the Material Icon Theme integration: file / folder → icon name.
+ * Pure and cheap to import (only the JSON tables); the asset URLs and the
+ * `import.meta.glob` over 1.2k SVGs live in `materialIcons.ts` so tests can
+ * exercise this logic without dragging every asset through the transform pipeline.
+ */
+export { DEFAULT_FILE_ICON, DEFAULT_FOLDER_ICON, DEFAULT_FOLDER_OPEN_ICON };
+
+// Widened from the literal JSON types so arbitrary user file names can index them.
+const FILE_EXTENSIONS: Record<string, string> = fileExtensions;
+const FILE_NAMES: Record<string, string> = fileNames;
+const FOLDER_NAMES: Record<string, string> = folderNames;
+const LIGHT_FILE_EXTENSIONS: Record<string, string> = light.fileExtensions;
+const LIGHT_FILE_NAMES: Record<string, string> = light.fileNames;
+const LIGHT_FOLDER_NAMES: Record<string, string> = light.folderNames;
+const LIGHT_FOLDER_NAMES_EXPANDED: Record<string, string> = light.folderNamesExpanded;
+
+/** Own-property lookup: a file literally named "constructor" must not hit Object.prototype. */
+function lookup(table: Record<string, string>, key: string): string | undefined {
+  return Object.prototype.hasOwnProperty.call(table, key) ? table[key] : undefined;
+}
+
+function lookupThemed(
+  lightTable: Record<string, string>,
+  table: Record<string, string>,
+  key: string,
+  isLight: boolean,
+): string | undefined {
+  return (isLight ? lookup(lightTable, key) : undefined) ?? lookup(table, key);
+}
+
+/** VS Code precedence: exact file name first, then the longest dotted suffix ("d.ts" beats "ts"). */
+export function fileIconName(name: string, ext: string | undefined, isLight: boolean): string {
+  const n = name.toLowerCase();
+  const byName = lookupThemed(LIGHT_FILE_NAMES, FILE_NAMES, n, isLight);
+  if (byName) return byName;
+
+  const parts = n.split(".");
+  for (let i = 1; i < parts.length; i++) {
+    const hit = lookupThemed(
+      LIGHT_FILE_EXTENSIONS,
+      FILE_EXTENSIONS,
+      parts.slice(i).join("."),
+      isLight,
+    );
+    if (hit) return hit;
+  }
+  if (ext) {
+    const hit = lookupThemed(LIGHT_FILE_EXTENSIONS, FILE_EXTENSIONS, ext.toLowerCase(), isLight);
+    if (hit) return hit;
+  }
+  return DEFAULT_FILE_ICON;
+}
+
+export function folderIconName(name: string, expanded: boolean, isLight: boolean): string {
+  const n = name.toLowerCase();
+  if (isLight) {
+    const hit = lookup(expanded ? LIGHT_FOLDER_NAMES_EXPANDED : LIGHT_FOLDER_NAMES, n);
+    if (hit) return hit;
+  }
+  const base = lookup(FOLDER_NAMES, n);
+  if (base) return expanded ? `${base}-open` : base;
+  return expanded ? DEFAULT_FOLDER_OPEN_ICON : DEFAULT_FOLDER_ICON;
+}
+
+/**
+ * Pick the first icon that actually exists.
+ *
+ * A few manifest entries point at "clone" icons that the extension generates at
+ * build time and the npm package does not ship (e.g. "svelte_ts", "angular-component",
+ * "folder-development-open"). Those degrade to their stem ("svelte", "angular",
+ * "folder-open") and finally to `fallback`.
+ */
+export function pickAvailableIcon(
+  isAvailable: (iconName: string) => boolean,
+  iconName: string,
+  fallback: string,
+): string {
+  const open = iconName.endsWith("-open");
+  let stem = open ? iconName.slice(0, -"-open".length) : iconName;
+  for (;;) {
+    const candidate = open ? `${stem}-open` : stem;
+    if (isAvailable(candidate)) return candidate;
+    const cut = Math.max(stem.lastIndexOf("-"), stem.lastIndexOf("_"));
+    if (cut <= 0) return fallback;
+    stem = stem.slice(0, cut);
+  }
+}

--- a/src/components/file-explorer/materialIcons.ts
+++ b/src/components/file-explorer/materialIcons.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_FILE_ICON,
+  DEFAULT_FOLDER_ICON,
+  DEFAULT_FOLDER_OPEN_ICON,
+  fileIconName,
+  folderIconName,
+  pickAvailableIcon,
+} from "./materialIconNames";
+
+/**
+ * File / folder icons from the Material Icon Theme
+ * (https://github.com/material-extensions/vscode-material-icon-theme, MIT).
+ *
+ * Every SVG in the package becomes a hashed static asset via `import.meta.glob`;
+ * the manifest lookup lives in `materialIconNames.ts`. Nothing from the package's
+ * JS runtime is executed or bundled. Cost: ~340 KB in the main bundle (mapping
+ * tables + 1.2k asset URLs) and ~1 MB of SVG files shipped alongside.
+ */
+
+/** icon name → asset URL, e.g. "react_ts" → "/assets/react_ts-abc123.svg". */
+const ICON_URLS: Record<string, string> = {};
+for (const [path, url] of Object.entries(
+  import.meta.glob<string>("/node_modules/material-icon-theme/icons/*.svg", {
+    eager: true,
+    query: "?no-inline",
+    import: "default",
+  }),
+)) {
+  ICON_URLS[path.slice(path.lastIndexOf("/") + 1, -".svg".length)] = url;
+}
+
+const hasIcon = (iconName: string) => Object.prototype.hasOwnProperty.call(ICON_URLS, iconName);
+
+export function getFileIconUrl(name: string, ext: string | undefined, isLight: boolean): string {
+  return ICON_URLS[pickAvailableIcon(hasIcon, fileIconName(name, ext, isLight), DEFAULT_FILE_ICON)];
+}
+
+export function getFolderIconUrl(name: string, expanded: boolean, isLight: boolean): string {
+  const fallback = expanded ? DEFAULT_FOLDER_OPEN_ICON : DEFAULT_FOLDER_ICON;
+  return ICON_URLS[pickAvailableIcon(hasIcon, folderIconName(name, expanded, isLight), fallback)];
+}

--- a/src/hooks/useIsLightTheme.ts
+++ b/src/hooks/useIsLightTheme.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * True while a light-family theme (light / eyecare) is active.
+ *
+ * App.tsx toggles the `dark` class on <html> for dark + midnight, so that class
+ * is the single source of truth. One shared MutationObserver fans changes out to
+ * every subscriber instead of each icon observing the document on its own.
+ */
+const listeners = new Set<() => void>();
+let observer: MutationObserver | null = null;
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (!observer) {
+    observer = new MutationObserver(() => listeners.forEach((notify) => notify()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      observer?.disconnect();
+      observer = null;
+    }
+  };
+}
+
+const getSnapshot = () => !document.documentElement.classList.contains("dark");
+
+export function useIsLightTheme(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/src/styles/file-explorer.css
+++ b/src/styles/file-explorer.css
@@ -1,0 +1,15 @@
+/* File explorer icons: Material Icon Theme SVGs rendered as <img>. */
+
+.file-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.file-icon[data-ignored="true"] {
+  opacity: 0.55;
+  filter: grayscale(1);
+}

--- a/src/styles/panels.ts
+++ b/src/styles/panels.ts
@@ -1135,18 +1135,6 @@ export const panels = {
     position: "absolute" as const,
     width: "100%",
   },
-  fileIconFolder: {
-    display: "inline-flex",
-    alignItems: "center",
-    flexShrink: 0,
-  },
-  fileIconFile: {
-    width: 5,
-    height: 14,
-    borderRadius: 2,
-    flexShrink: 0,
-    display: "inline-block",
-  },
   fileTreeRow: {
     display: "flex",
     alignItems: "center",

--- a/src/test/materialIconNames.test.ts
+++ b/src/test/materialIconNames.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  fileIconName,
+  folderIconName,
+  pickAvailableIcon,
+} from "../components/file-explorer/materialIconNames";
+
+describe("materialIconNames: file lookup", () => {
+  it("按扩展名匹配，最长的点分后缀优先", () => {
+    expect(fileIconName("utils.ts", undefined, false)).toBe("typescript");
+    expect(fileIconName("App.tsx", undefined, false)).toBe("react_ts");
+    expect(fileIconName("types.d.ts", undefined, false)).toBe("typescript-def");
+  });
+
+  it("特殊文件名优先于扩展名，且大小写不敏感", () => {
+    expect(fileIconName("package.json", undefined, false)).toBe("nodejs");
+    expect(fileIconName("Dockerfile", undefined, false)).toBe("docker");
+    expect(fileIconName(".gitignore", undefined, false)).toBe("git");
+  });
+
+  it("显式 ext 参数作为兜底", () => {
+    expect(fileIconName("weird", "rs", false)).toBe("rust");
+  });
+
+  it("未知文件回落通用图标，且不会命中 Object.prototype", () => {
+    expect(fileIconName("NOTICE", undefined, false)).toBe("file");
+    expect(fileIconName("constructor", undefined, false)).toBe("file");
+    expect(fileIconName("a.toString", undefined, false)).toBe("file");
+  });
+
+  it("亮色主题使用 _light 变体", () => {
+    const dark = fileIconName(".rubocop.yml", undefined, false);
+    const light = fileIconName(".rubocop.yml", undefined, true);
+    expect(light).not.toBe(dark);
+    expect(light).toMatch(/_light$/);
+  });
+});
+
+describe("materialIconNames: folder lookup", () => {
+  it("已知目录名有专属图标，展开态加 -open", () => {
+    expect(folderIconName("src", false, false)).toBe("folder-src");
+    expect(folderIconName("src", true, false)).toBe("folder-src-open");
+    expect(folderIconName("node_modules", false, false)).toBe("folder-node");
+  });
+
+  it("未知目录回落通用文件夹", () => {
+    expect(folderIconName("zzz-unknown", false, false)).toBe("folder");
+    expect(folderIconName("zzz-unknown", true, false)).toBe("folder-open");
+  });
+});
+
+describe("materialIconNames: pickAvailableIcon", () => {
+  const available = new Set(["svelte", "angular", "folder", "folder-open", "file", "react_ts"]);
+  const has = (name: string) => available.has(name);
+
+  it("存在的图标原样返回", () => {
+    expect(pickAvailableIcon(has, "react_ts", "file")).toBe("react_ts");
+  });
+
+  it("npm 包未附带的 clone 图标退化到其 stem，-open 后缀保留", () => {
+    // manifest maps "*.svelte.ts" → "svelte_ts", which only exists as a build-time clone
+    expect(fileIconName("Store.svelte.ts", undefined, false)).toBe("svelte_ts");
+    expect(pickAvailableIcon(has, "svelte_ts", "file")).toBe("svelte");
+    expect(pickAvailableIcon(has, "angular-component", "file")).toBe("angular");
+    expect(pickAvailableIcon(has, "folder-development-open", "folder-open")).toBe("folder-open");
+  });
+
+  it("完全未知的名字回落 fallback", () => {
+    expect(pickAvailableIcon(has, "nosuchicon", "file")).toBe("file");
+    expect(pickAvailableIcon(has, "no-such-icon-xyz", "file")).toBe("file");
+  });
+});


### PR DESCRIPTION
The explorer, search results, drag preview and create-input row showed a 5px colour bar per file type. Replace it with the Material Icon Theme SVGs (material-icon-theme, MIT): per-extension and per-filename icons with VS Code precedence, dedicated folder icons (src, node_modules, tests...), and _light variants under light / eyecare themes.

Only the manifest tables and SVGs are consumed; the package's JS runtime is not bundled. Main bundle grows ~350 KB, plus ~1 MB of SVG assets. Manifest lookup lives in materialIconNames.ts so tests avoid importing the 1.2k-asset glob.