### PR TITLE
fix(git): use material file icons in the change browser

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -18,7 +18,7 @@ import { load, save } from "../utils";
 import { writeClipboardText } from "./file-explorer/clipboard";
 import { FileExplorerContextMenu } from "./file-explorer/ContextMenu";
 import { CreateInputRow } from "./file-explorer/CreateInputRow";
-import { FileIcon } from "./file-explorer/FileIcon";
+import { FileIcon } from "./FileIcon";
 import { TreeItem } from "./file-explorer/TreeItem";
 import { dispatchFileTreePointerDrag } from "./pathDrop";
 import {

--- a/src/components/FileIcon.tsx
+++ b/src/components/FileIcon.tsx
@@ -1,10 +1,11 @@
-import { useIsLightTheme } from "../../hooks/useIsLightTheme";
-import { getFileIconUrl, getFolderIconUrl } from "./materialIcons";
+import { useIsLightTheme } from "../hooks/useIsLightTheme";
+import { getFileIconUrl, getFolderIconUrl } from "./file-explorer/materialIcons";
 
 /**
- * File / folder icon for explorer rows, search results, drag previews and the
- * create-input row. Renders a Material Icon Theme SVG as a plain <img>;
- * gitignored entries are greyed out purely in CSS (`data-ignored`).
+ * File / folder icon shared by the explorer rows, search results, drag previews,
+ * the create-input row and the git change / history browser. Renders a Material
+ * Icon Theme SVG as a plain <img>; gitignored entries are greyed out purely in
+ * CSS (`data-ignored`).
  */
 export function FileIcon({
   name,

--- a/src/components/file-explorer/CreateInputRow.tsx
+++ b/src/components/file-explorer/CreateInputRow.tsx
@@ -1,5 +1,5 @@
 import s from "../../styles";
-import { FileIcon } from "./FileIcon";
+import { FileIcon } from "../FileIcon";
 import { type CreateKind } from "./types";
 
 export function CreateInputRow({

--- a/src/components/file-explorer/SearchPanel.tsx
+++ b/src/components/file-explorer/SearchPanel.tsx
@@ -4,7 +4,7 @@ import { Check, ChevronDown, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import s from "../../styles";
 import { useI18n } from "../../i18n";
-import { FileIcon } from "./FileIcon";
+import { FileIcon } from "../FileIcon";
 import type { ProjectFileSearchResult } from "./types";
 
 const SEARCH_DEBOUNCE_MS = 200;

--- a/src/components/file-explorer/TreeItem.tsx
+++ b/src/components/file-explorer/TreeItem.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import s from "../../styles";
-import { FileIcon } from "./FileIcon";
+import { FileIcon } from "../FileIcon";
 import { FILE_TREE_HOVER_BG, GITIGNORED_COLOR, type TreeNode } from "./types";
 
 export function TreeItem({

--- a/src/components/git-view/GitFileBrowser.tsx
+++ b/src/components/git-view/GitFileBrowser.tsx
@@ -1,16 +1,8 @@
 import type React from "react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import {
-  ChevronDown,
-  ChevronRight,
-  File,
-  Folder,
-  FolderOpen,
-  List,
-  ListTree,
-  Undo2,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, List, ListTree, Undo2 } from "lucide-react";
 import { useI18n } from "../../i18n";
+import { FileIcon } from "../FileIcon";
 import s from "../../styles";
 import {
   GIT_FILE_BROWSER_MAX_HEIGHT,
@@ -24,7 +16,7 @@ import {
   gitFileVirtualListStyle,
   gitFileVirtualRowStyle,
 } from "../../styles/git-diff";
-import { getFileColor, getGitStatusColor, getGitStatusLabel, load, save } from "../../utils";
+import { getGitStatusColor, getGitStatusLabel, load, save } from "../../utils";
 
 export type GitFileViewMode = "tree" | "list";
 
@@ -398,9 +390,7 @@ function GitDirectoryRow<T extends GitFileEntry>({
         <span style={s.gitFileChevron}>
           {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </span>
-        <span style={s.gitFileFolderIcon}>
-          {expanded ? <FolderOpen size={13} /> : <Folder size={13} />}
-        </span>
+        <FileIcon name={node.name} isDir expanded={expanded} />
         <span style={s.gitFileDirectoryName}>{node.name}</span>
       </button>
       {showStats && (
@@ -500,7 +490,7 @@ function GitFileRow<T extends GitFileEntry>({
     >
       <span style={gitFileStatusDotStyle(color)} />
       <span style={gitFileStatusLabelStyle(color)}>{label}</span>
-      <File size={13} color={getFileColor(name)} style={s.gitFileIcon} aria-hidden="true" />
+      <FileIcon name={name} isDir={false} />
       <span style={s.gitFileNameWrap}>
         <span style={hovered && clickable ? s.gitFileNameHover : s.gitFileName}>{name}</span>
         {mode === "list" && dir && <span style={s.gitFileDir}>{dir}</span>}

--- a/src/styles/file-explorer.css
+++ b/src/styles/file-explorer.css
@@ -1,4 +1,4 @@
-/* File explorer icons: Material Icon Theme SVGs rendered as <img>. */
+/* File / folder icons: Material Icon Theme SVGs rendered as <img>. */
 
 .file-icon {
   width: 16px;

--- a/src/styles/git-diff.ts
+++ b/src/styles/git-diff.ts
@@ -553,15 +553,6 @@ export const gitDiff = {
     color: "var(--text-hint)",
     flexShrink: 0,
   },
-  gitFileFolderIcon: {
-    display: "flex",
-    alignItems: "center",
-    color: "var(--text-muted)",
-    flexShrink: 0,
-  },
-  gitFileIcon: {
-    flexShrink: 0,
-  },
   gitFileName: {
     fontSize: 12.5,
     fontWeight: 500,


### PR DESCRIPTION
The git change / history rows fell back to a single monochrome lucide File glyph, so every file looked the same while the file explorer next to it already showed per-language Material icons. Reuse that icon component here instead of keeping a second, weaker icon vocabulary.

FileIcon moves up to components/ so git-view does not have to reach into the file-explorer subdirectory for it.